### PR TITLE
Additional fixes to save method.

### DIFF
--- a/index.js
+++ b/index.js
@@ -61,12 +61,12 @@ class PDFMerger {
 
   async save (fileName) {
     try {
-      var writeSream = this.doc.pipe(fs.createWriteStream(fileName))
+      var writeStream = this.doc.pipe(fs.createWriteStream(fileName))
       await this.doc.end()
 
       var writeStreamClosedPromise = new Promise((resolve, reject) => {
         try {
-          writeSream.on('close', () => resolve(output));
+          writeStream.on('close', () => resolve());
         } catch (e) {
           reject(e);
         }

--- a/index.js
+++ b/index.js
@@ -61,8 +61,19 @@ class PDFMerger {
 
   async save (fileName) {
     try {
-      this.doc.pipe(fs.createWriteStream(fileName))
+      var writeSream = this.doc.pipe(fs.createWriteStream(fileName))
       await this.doc.end()
+
+      var writeStreamClosedPromise = new Promise((resolve, reject) => {
+        try {
+          writeSream.on('close', () => resolve(output));
+        } catch (e) {
+          reject(e);
+        }
+      });
+
+      return writeStreamClosedPromise;
+
     } catch (error) {
       console.log(error)
     }


### PR DESCRIPTION
This is based off of #11. This fixes a mispelling and removes an undefined `output` variable in the resolve function. The previous PR fixed an issue we had where we were copying a merged pdf before it was finished writing, leading to a corrupted pdf.