### PR TITLE
Fixes declare issue with new version of Typescript

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Alexander Wunschik <https://github.com/mojoaxel/>
 
 declare module "pdf-merger-js" {
-  declare class PDFMerger {
+  class PDFMerger {
     constructor();
     add(inputFile: string, pages?: string | string[] | undefined | null): undefined;
     save(fileName: string): Promise<undefined>;


### PR DESCRIPTION
This nested declare makes the npx tsc fail with the next error:
node_modules/pdf-merger-js/index.d.ts(6,3): error TS1038: A 'declare' modifier cannot be used in an already ambient context.