### PR TITLE
Allow output directly to buffer

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -7,6 +7,7 @@ declare module "pdf-merger-js" {
     constructor();
     add(inputFile: string | Buffer, pages?: string | string[] | undefined | null): undefined;
     save(fileName: string): Promise<undefined>;
+    saveAsBuffer(): Promise<Buffer>;
   }
 
   export = PDFMerger;

--- a/index.js
+++ b/index.js
@@ -72,6 +72,10 @@ class PDFMerger {
       console.log(error)
     }
   }
+
+  async saveAsBuffer () {
+    return this.doc.asBuffer()
+  }
 }
 
 module.exports = PDFMerger


### PR DESCRIPTION
I would love to be able to save the merged pdf directly to a buffer

pdfjs supports it as [`asBuffer()`](https://github.com/rkusa/pdfjs/blob/master/docs/document.md#asbufferopts-callback), so i just added it