### PR TITLE
Create Browser compatible version with Promises and FileReader

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,27 +11,27 @@ This library is inspired by the [PHP library PDFMerger](https://github.com/myoky
 ## Code sample
 
 ```javascript
-const PDFMerger = require("pdf-merger-js");
+const PDFMerger = require('pdf-merger-js');
 
 var merger = new PDFMerger();
 
 (async () => {
-  merger.add("pdf1.pdf"); //merge all pages. parameter is the path to file and filename.
-  merger.add("pdf2.pdf", [2]); // merge only page 2
-  merger.add("pdf2.pdf", [1, 3]); // merge the pages 1 and 3
-  merger.add("pdf2.pdf", "4, 7, 8"); // merge the pages 4, 7 and 8
-  merger.add("pdf3.pdf", "1 to 2"); //merge pages 1 to 2
-  merger.add("pdf3.pdf", "3-4"); //merge pages 3 to 4
+  merger.add('pdf1.pdf'); //merge all pages. parameter is the path to file and filename.
+  merger.add('pdf2.pdf', [2]); // merge only page 2
+  merger.add('pdf2.pdf', [1, 3]); // merge the pages 1 and 3
+  merger.add('pdf2.pdf', '4, 7, 8'); // merge the pages 4, 7 and 8
+  merger.add('pdf3.pdf', '1 to 2'); //merge pages 1 to 2
+  merger.add('pdf3.pdf', '3-4'); //merge pages 3 to 4
 
-  await merger.save("merged.pdf"); //save under given name and reset the internal document
+  await merger.save('merged.pdf'); //save under given name and reset the internal document
 })();
 ```
 
 ### Browser Sample - React
 
 ```javascript
-import PDFMerger from "pdf-merger-js/browser";
-import React, { useEffect, useState } from "react";
+import PDFMerger from 'pdf-merger-js/browser';
+import React, { useEffect, useState } from 'react';
 
 // files: Array of PDF File or Blob objects
 const Merger = (files) => {
@@ -62,8 +62,8 @@ const Merger = (files) => {
     <iframe
       height={1000}
       src={`${mergedPdfUrl}`}
-      title="pdf-viewer"
-      width="100%s"
+      title='pdf-viewer'
+      width='100%s'
     ></iframe>
   );
 };
@@ -71,6 +71,6 @@ const Merger = (files) => {
 
 ## Similar libraries
 
-- [pdf-merge](https://www.npmjs.com/package/pdf-merge) has a dependency on [PDFtk](https://www.pdflabs.com/tools/pdftk-the-pdf-toolkit/).
-- [easy-pdf-merge](https://www.npmjs.com/package/easy-pdf-merge) has a dependency on the [Apache PDFBox® - A Java PDF Library](https://pdfbox.apache.org/).
-- [pdfmerge](https://www.npmjs.com/package/pdfmerge) has a dependency on python and [PyPDF2](https://pythonhosted.org/PyPDF2/).
+* [pdf-merge](https://www.npmjs.com/package/pdf-merge) has a dependency on [PDFtk](https://www.pdflabs.com/tools/pdftk-the-pdf-toolkit/).
+* [easy-pdf-merge](https://www.npmjs.com/package/easy-pdf-merge) has a dependency on the [Apache PDFBox® - A Java PDF Library](https://pdfbox.apache.org/).
+* [pdfmerge](https://www.npmjs.com/package/pdfmerge) has a dependency on python and [PyPDF2](https://pythonhosted.org/PyPDF2/).

--- a/README.md
+++ b/README.md
@@ -11,24 +11,66 @@ This library is inspired by the [PHP library PDFMerger](https://github.com/myoky
 ## Code sample
 
 ```javascript
-const PDFMerger = require('pdf-merger-js');
+const PDFMerger = require("pdf-merger-js");
 
 var merger = new PDFMerger();
 
 (async () => {
-  merger.add('pdf1.pdf');  //merge all pages. parameter is the path to file and filename.
-  merger.add('pdf2.pdf', [2]); // merge only page 2
-  merger.add('pdf2.pdf', [1, 3]); // merge the pages 1 and 3
-  merger.add('pdf2.pdf', '4, 7, 8'); // merge the pages 4, 7 and 8
-  merger.add('pdf3.pdf', '1 to 2'); //merge pages 1 to 2
-  merger.add('pdf3.pdf', '3-4'); //merge pages 3 to 4
+  merger.add("pdf1.pdf"); //merge all pages. parameter is the path to file and filename.
+  merger.add("pdf2.pdf", [2]); // merge only page 2
+  merger.add("pdf2.pdf", [1, 3]); // merge the pages 1 and 3
+  merger.add("pdf2.pdf", "4, 7, 8"); // merge the pages 4, 7 and 8
+  merger.add("pdf3.pdf", "1 to 2"); //merge pages 1 to 2
+  merger.add("pdf3.pdf", "3-4"); //merge pages 3 to 4
 
-  await merger.save('merged.pdf'); //save under given name and reset the internal document
+  await merger.save("merged.pdf"); //save under given name and reset the internal document
 })();
+```
+
+### Browser Sample - React
+
+```javascript
+import PDFMerger from "pdf-merger-js/browser";
+import React, { useEffect, useState } from "react";
+
+// files: Array of PDF File or Blob objects
+const Merger = (files) => {
+  const [mergedPdfUrl, setMergedPdfUrl] = useState();
+
+  useEffect(() => {
+    const render = async () => {
+      const merger = new PDFMerger();
+
+      await Promise.all(files.map(async (file) => await merger.add(file)));
+
+      const mergedPdf = await merger.saveAsBlob();
+      const url = URL.createObjectURL(mergedPdf);
+
+      return setMergedPdfUrl(url);
+    };
+
+    render().catch((err) => {
+      throw err;
+    });
+
+    () => setMergedPdfUrl({});
+  }, [files, setMergedPdfUrl]);
+
+  return !data ? (
+    <>Loading</>
+  ) : (
+    <iframe
+      height={1000}
+      src={`${mergedPdfUrl}`}
+      title="pdf-viewer"
+      width="100%s"
+    ></iframe>
+  );
+};
 ```
 
 ## Similar libraries
 
-* [pdf-merge](https://www.npmjs.com/package/pdf-merge) has a dependency on [PDFtk](https://www.pdflabs.com/tools/pdftk-the-pdf-toolkit/).
-* [easy-pdf-merge](https://www.npmjs.com/package/easy-pdf-merge) has a dependency on the [Apache PDFBox® - A Java PDF Library](https://pdfbox.apache.org/).
-* [pdfmerge](https://www.npmjs.com/package/pdfmerge) has a dependency on python and [PyPDF2](https://pythonhosted.org/PyPDF2/).
+- [pdf-merge](https://www.npmjs.com/package/pdf-merge) has a dependency on [PDFtk](https://www.pdflabs.com/tools/pdftk-the-pdf-toolkit/).
+- [easy-pdf-merge](https://www.npmjs.com/package/easy-pdf-merge) has a dependency on the [Apache PDFBox® - A Java PDF Library](https://pdfbox.apache.org/).
+- [pdfmerge](https://www.npmjs.com/package/pdfmerge) has a dependency on python and [PyPDF2](https://pythonhosted.org/PyPDF2/).

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ const PDFMerger = require('pdf-merger-js');
 var merger = new PDFMerger();
 
 (async () => {
-  merger.add('pdf1.pdf'); //merge all pages. parameter is the path to file and filename.
+  merger.add('pdf1.pdf');  //merge all pages. parameter is the path to file and filename.
   merger.add('pdf2.pdf', [2]); // merge only page 2
   merger.add('pdf2.pdf', [1, 3]); // merge the pages 1 and 3
   merger.add('pdf2.pdf', '4, 7, 8'); // merge the pages 4, 7 and 8

--- a/browser.js
+++ b/browser.js
@@ -1,127 +1,127 @@
-const pdf = require('pdfjs');
+const pdf = require('pdfjs')
 
 class PDFMerger {
-  constructor() {
-    this._resetDoc();
-    console.log('linked version');
+  constructor () {
+    this._resetDoc()
+    console.log('linked version')
   }
 
-  add(inputFile, pages) {
+  add (inputFile, pages) {
     if (typeof pages === 'undefined' || pages === null) {
-      return this._addEntireDocument(inputFile, pages);
+      return this._addEntireDocument(inputFile, pages)
     } else if (Array.isArray(pages)) {
-      return this._addGivenPages(inputFile, pages);
+      return this._addGivenPages(inputFile, pages)
     } else if (pages.indexOf(',') > 0) {
-      return this._addGivenPages(inputFile, pages.replace(/ /g, '').split(','));
+      return this._addGivenPages(inputFile, pages.replace(/ /g, '').split(','))
     } else if (pages.toLowerCase().indexOf('to') >= 0) {
-      const span = pages.replace(/ /g, '').split('to');
+      const span = pages.replace(/ /g, '').split('to')
       return this._addFromToPage(
         inputFile,
         parseInt(span[0]),
         parseInt(span[1])
-      );
+      )
     } else if (pages.indexOf('-') >= 0) {
-      const span = pages.replace(/ /g, '').split('-');
+      const span = pages.replace(/ /g, '').split('-')
       return this._addFromToPage(
         inputFile,
         parseInt(span[0]),
         parseInt(span[1])
-      );
+      )
     } else {
-      console.error('invalid parameter "pages"');
+      console.error('invalid parameter "pages"')
     }
   }
 
-  _resetDoc() {
+  _resetDoc () {
     if (this.doc) {
-      delete this.doc;
+      delete this.doc
     }
-    this.doc = new pdf.Document();
+    this.doc = new pdf.Document()
   }
 
-  async _getInputFile(inputFile) {
+  async _getInputFile (inputFile) {
     return new Promise((resolve) => {
       if (inputFile instanceof Buffer) {
-        resolve(inputFile);
+        resolve(inputFile)
       } else {
-        const fileReader = new FileReader();
+        const fileReader = new window.FileReader()
 
         fileReader.onload = function (evt) {
-          resolve(fileReader.result);
-        };
+          resolve(fileReader.result)
+        }
 
-        fileReader.readAsArrayBuffer(inputFile);
+        fileReader.readAsArrayBuffer(inputFile)
       }
-    });
+    })
   }
 
-  async _addEntireDocument(inputFile) {
-    const src = await this._getInputFile(inputFile);
-    console.log(src);
-    const ext = new pdf.ExternalDocument(src);
+  async _addEntireDocument (inputFile) {
+    const src = await this._getInputFile(inputFile)
+    console.log(src)
+    const ext = new pdf.ExternalDocument(src)
 
-    return this.doc.addPagesOf(ext);
+    return this.doc.addPagesOf(ext)
   }
 
-  async _addFromToPage(inputFile, from, to) {
+  async _addFromToPage (inputFile, from, to) {
     if (
       typeof from === 'number' &&
       typeof to === 'number' &&
       from > 0 &&
       to > from
     ) {
-      let pages = [];
+      const pages = []
 
       for (let i = from; i <= to; i++) {
-        pages.push(i);
+        pages.push(i)
       }
 
-      const src = await this._getInputFile(inputFile);
-      const ext = new pdf.ExternalDocument(src);
-      this.doc.setTemplate(ext);
+      const src = await this._getInputFile(inputFile)
+      const ext = new pdf.ExternalDocument(src)
+      this.doc.setTemplate(ext)
 
       return Promise.all(
         pages.map(async (page) => this.doc.addPageOf(page, ext))
-      );
+      )
     } else {
-      console.log('invalid function parameter');
+      console.log('invalid function parameter')
     }
   }
 
-  async _addGivenPages(inputFile, pages) {
+  async _addGivenPages (inputFile, pages) {
     if (pages.length > 0) {
-      const src = await this._getInputFile(inputFile);
-      const ext = new pdf.ExternalDocument(src);
-      this.doc.setTemplate(ext);
+      const src = await this._getInputFile(inputFile)
+      const ext = new pdf.ExternalDocument(src)
+      this.doc.setTemplate(ext)
 
       return Promise.all(
         pages.map(async (page) => {
-          this.doc.addPageOf(page, ext);
+          this.doc.addPageOf(page, ext)
         })
-      );
+      )
     }
   }
 
-  async saveAsBuffer() {
-    return this.doc.asBuffer();
+  async saveAsBuffer () {
+    return this.doc.asBuffer()
   }
 
-  async saveAsBlob() {
-    const buffer = await this.saveAsBuffer();
+  async saveAsBlob () {
+    const buffer = await this.saveAsBuffer()
 
-    return new Blob([buffer], {
-      type: `application/pdf`,
-    });
+    return new window.Blob([buffer], {
+      type: 'application/pdf'
+    })
   }
 
-  async save(fileName) {
-    const blob = await this.saveAsBlob();
+  async save (fileName) {
+    const blob = await this.saveAsBlob()
 
-    const link = document.createElement('a');
-    link.href = window.URL.createObjectURL(blob);
-    link.download = `${fileName}.pdf`;
-    link.click();
+    const link = document.createElement('a')
+    link.href = window.URL.createObjectURL(blob)
+    link.download = `${fileName}.pdf`
+    link.click()
   }
 }
 
-module.exports = PDFMerger;
+module.exports = PDFMerger

--- a/browser.js
+++ b/browser.js
@@ -3,6 +3,7 @@ const pdf = require('pdfjs');
 class PDFMerger {
   constructor() {
     this._resetDoc();
+    console.log('linked version');
   }
 
   add(inputFile, pages) {
@@ -56,6 +57,7 @@ class PDFMerger {
 
   async _addEntireDocument(inputFile) {
     const src = await this._getInputFile(inputFile);
+    console.log(src);
     const ext = new pdf.ExternalDocument(src);
 
     return this.doc.addPagesOf(ext);

--- a/browser.js
+++ b/browser.js
@@ -1,4 +1,4 @@
-const pdf = require("pdfjs");
+const pdf = require('pdfjs');
 
 class PDFMerger {
   constructor() {
@@ -6,21 +6,21 @@ class PDFMerger {
   }
 
   add(inputFile, pages) {
-    if (typeof pages === "undefined" || pages === null) {
+    if (typeof pages === 'undefined' || pages === null) {
       return this._addEntireDocument(inputFile, pages);
     } else if (Array.isArray(pages)) {
       return this._addGivenPages(inputFile, pages);
-    } else if (pages.indexOf(",") > 0) {
-      return this._addGivenPages(inputFile, pages.replace(/ /g, "").split(","));
-    } else if (pages.toLowerCase().indexOf("to") >= 0) {
-      const span = pages.replace(/ /g, "").split("to");
+    } else if (pages.indexOf(',') > 0) {
+      return this._addGivenPages(inputFile, pages.replace(/ /g, '').split(','));
+    } else if (pages.toLowerCase().indexOf('to') >= 0) {
+      const span = pages.replace(/ /g, '').split('to');
       return this._addFromToPage(
         inputFile,
         parseInt(span[0]),
         parseInt(span[1])
       );
-    } else if (pages.indexOf("-") >= 0) {
-      const span = pages.replace(/ /g, "").split("-");
+    } else if (pages.indexOf('-') >= 0) {
+      const span = pages.replace(/ /g, '').split('-');
       return this._addFromToPage(
         inputFile,
         parseInt(span[0]),
@@ -61,8 +61,8 @@ class PDFMerger {
 
   async _addFromToPage(inputFile, from, to) {
     if (
-      typeof from === "number" &&
-      typeof to === "number" &&
+      typeof from === 'number' &&
+      typeof to === 'number' &&
       from > 0 &&
       to > from
     ) {
@@ -80,7 +80,7 @@ class PDFMerger {
         pages.map(async (page) => this.doc.addPageOf(page, ext))
       );
     } else {
-      console.log("invalid function parameter");
+      console.log('invalid function parameter');
     }
   }
 
@@ -113,7 +113,7 @@ class PDFMerger {
   async save(fileName) {
     const blob = await this.saveAsBlob();
 
-    const link = document.createElement("a");
+    const link = document.createElement('a');
     link.href = window.URL.createObjectURL(blob);
     link.download = `${fileName}.pdf`;
     link.click();

--- a/browser.js
+++ b/browser.js
@@ -1,0 +1,123 @@
+const pdf = require("pdfjs");
+
+class PDFMerger {
+  constructor() {
+    this._resetDoc();
+  }
+
+  add(inputFile, pages) {
+    if (typeof pages === "undefined" || pages === null) {
+      return this._addEntireDocument(inputFile, pages);
+    } else if (Array.isArray(pages)) {
+      return this._addGivenPages(inputFile, pages);
+    } else if (pages.indexOf(",") > 0) {
+      return this._addGivenPages(inputFile, pages.replace(/ /g, "").split(","));
+    } else if (pages.toLowerCase().indexOf("to") >= 0) {
+      const span = pages.replace(/ /g, "").split("to");
+      return this._addFromToPage(
+        inputFile,
+        parseInt(span[0]),
+        parseInt(span[1])
+      );
+    } else if (pages.indexOf("-") >= 0) {
+      const span = pages.replace(/ /g, "").split("-");
+      return this._addFromToPage(
+        inputFile,
+        parseInt(span[0]),
+        parseInt(span[1])
+      );
+    } else {
+      console.error('invalid parameter "pages"');
+    }
+  }
+
+  _resetDoc() {
+    if (this.doc) {
+      delete this.doc;
+    }
+    this.doc = new pdf.Document();
+  }
+
+  async _getInputFile(inputFile) {
+    if (inputFile instanceof Buffer) {
+      return inputFile;
+    } else {
+      const fileReader = new FileReader();
+
+      fileReader.onload = function (evt) {
+        return fileReader.result;
+      };
+
+      fileReader.readAsArrayBuffer(inputFile);
+    }
+  }
+
+  async _addEntireDocument(inputFile) {
+    const src = await this._getInputFile(inputFile);
+    const ext = new pdf.ExternalDocument(src);
+
+    return this.doc.addPagesOf(ext);
+  }
+
+  async _addFromToPage(inputFile, from, to) {
+    if (
+      typeof from === "number" &&
+      typeof to === "number" &&
+      from > 0 &&
+      to > from
+    ) {
+      let pages = [];
+
+      for (let i = from; i <= to; i++) {
+        pages.push(i);
+      }
+
+      const src = await this._getInputFile(inputFile);
+      const ext = new pdf.ExternalDocument(src);
+      this.doc.setTemplate(ext);
+
+      return Promise.all(
+        pages.map(async (page) => this.doc.addPageOf(page, ext))
+      );
+    } else {
+      console.log("invalid function parameter");
+    }
+  }
+
+  async _addGivenPages(inputFile, pages) {
+    if (pages.length > 0) {
+      const src = await this._getInputFile(inputFile);
+      const ext = new pdf.ExternalDocument(src);
+      this.doc.setTemplate(ext);
+
+      return Promise.all(
+        pages.map(async (page) => {
+          this.doc.addPageOf(page, ext);
+        })
+      );
+    }
+  }
+
+  async saveAsBuffer() {
+    return this.doc.asBuffer();
+  }
+
+  async saveAsBlob() {
+    const buffer = await this.saveAsBuffer();
+
+    return new Blob([buffer], {
+      type: `application/pdf`,
+    });
+  }
+
+  async save(fileName) {
+    const blob = await this.saveAsBlob();
+
+    const link = document.createElement("a");
+    link.href = window.URL.createObjectURL(blob);
+    link.download = `${fileName}.pdf`;
+    link.click();
+  }
+}
+
+module.exports = PDFMerger;

--- a/test/browser-fixtures.test.js
+++ b/test/browser-fixtures.test.js
@@ -1,145 +1,145 @@
-const path = require('path');
-const fs = require('fs-extra');
-const pdfDiff = require('pdf-diff');
+const path = require('path')
+const fs = require('fs-extra')
+const pdfDiff = require('pdf-diff')
 
-const PDFMerger = require('../browser');
+const PDFMerger = require('../browser')
 
-const FIXTURES_DIR = path.join(__dirname, 'fixtures');
-const TMP_DIR = path.join(__dirname, 'tmp');
+const FIXTURES_DIR = path.join(__dirname, 'fixtures')
+const TMP_DIR = path.join(__dirname, 'tmp')
 
-jest.setTimeout(10000);
+jest.setTimeout(10000)
 
 // Note: The browser tests differ from standard as all files are expected
 // to be generated or fetched before being passed into the merger.
 // For testing, they are retrieved with fs.ReadFile() and then passed in.
 describe('PDFMerger', () => {
   beforeAll(async () => {
-    await fs.ensureDir(TMP_DIR);
-  });
+    await fs.ensureDir(TMP_DIR)
+  })
 
   test('merge two simple files', async () => {
-    const merger = new PDFMerger();
+    const merger = new PDFMerger()
 
     await merger.add(
       await fs.readFile(path.join(FIXTURES_DIR, 'Testfile_A.pdf'))
-    );
+    )
     await merger.add(
       await fs.readFile(path.join(FIXTURES_DIR, 'Testfile_B.pdf'))
-    );
+    )
 
-    const buffer = await merger.saveAsBuffer();
+    const buffer = await merger.saveAsBuffer()
     // Write the buffer as a file for pdfDiff
-    await fs.writeFile(path.join(TMP_DIR, 'Testfile_AB.pdf'), buffer);
+    await fs.writeFile(path.join(TMP_DIR, 'Testfile_AB.pdf'), buffer)
 
     const diff = await pdfDiff(
       path.join(FIXTURES_DIR, 'Testfile_AB.pdf'),
       path.join(TMP_DIR, 'Testfile_AB.pdf')
-    );
+    )
 
-    expect(diff).toBeFalsy();
-  });
+    expect(diff).toBeFalsy()
+  })
 
   test('combine pages from multiple books (array)', async () => {
-    const merger = new PDFMerger();
-    const tmpFile = 'MergeDemo1.pdf';
+    const merger = new PDFMerger()
+    const tmpFile = 'MergeDemo1.pdf'
 
     await merger.add(
       await fs.readFile(path.join(FIXTURES_DIR, 'Testfile_AB.pdf')),
       [1]
-    );
+    )
     await merger.add(
       await fs.readFile(path.join(FIXTURES_DIR, 'UDHR.pdf')),
       [1, 2, 3]
-    );
+    )
 
-    const buffer = await merger.saveAsBuffer();
+    const buffer = await merger.saveAsBuffer()
     // Write the buffer as a file for pdfDiff
-    await fs.writeFile(path.join(TMP_DIR, tmpFile), buffer);
+    await fs.writeFile(path.join(TMP_DIR, tmpFile), buffer)
 
     const diff = await pdfDiff(
       path.join(FIXTURES_DIR, 'MergeDemo.pdf'),
       path.join(TMP_DIR, tmpFile)
-    );
+    )
 
-    expect(diff).toBeFalsy();
-  });
+    expect(diff).toBeFalsy()
+  })
 
   test('combine pages from multiple books (start-end)', async () => {
-    const merger = new PDFMerger();
-    const tmpFile = 'MergeDemo2.pdf';
+    const merger = new PDFMerger()
+    const tmpFile = 'MergeDemo2.pdf'
 
     await merger.add(
       await fs.readFile(path.join(FIXTURES_DIR, 'Testfile_AB.pdf')),
       [1]
-    );
+    )
     await merger.add(
       await fs.readFile(path.join(FIXTURES_DIR, 'UDHR.pdf')),
       '1-3'
-    );
+    )
 
-    const buffer = await merger.saveAsBuffer();
+    const buffer = await merger.saveAsBuffer()
     // Write the buffer as a file for pdfDiff
-    await fs.writeFile(path.join(TMP_DIR, tmpFile), buffer);
+    await fs.writeFile(path.join(TMP_DIR, tmpFile), buffer)
 
     const diff = await pdfDiff(
       path.join(FIXTURES_DIR, 'MergeDemo.pdf'),
       path.join(TMP_DIR, tmpFile)
-    );
+    )
 
-    expect(diff).toBeFalsy();
-  });
+    expect(diff).toBeFalsy()
+  })
 
   test('combine pages from multiple books (start - end)', async () => {
-    const merger = new PDFMerger();
-    const tmpFile = 'MergeDemo2.pdf';
+    const merger = new PDFMerger()
+    const tmpFile = 'MergeDemo2.pdf'
 
     await merger.add(
       await fs.readFile(path.join(FIXTURES_DIR, 'Testfile_AB.pdf')),
       [1]
-    );
+    )
     await merger.add(
       await fs.readFile(path.join(FIXTURES_DIR, 'UDHR.pdf')),
       '1 - 3'
-    );
+    )
 
-    const buffer = await merger.saveAsBuffer();
+    const buffer = await merger.saveAsBuffer()
     // Write the buffer as a file for pdfDiff
-    await fs.writeFile(path.join(TMP_DIR, tmpFile), buffer);
+    await fs.writeFile(path.join(TMP_DIR, tmpFile), buffer)
 
     const diff = await pdfDiff(
       path.join(FIXTURES_DIR, 'MergeDemo.pdf'),
       path.join(TMP_DIR, tmpFile)
-    );
+    )
 
-    expect(diff).toBeFalsy();
-  });
+    expect(diff).toBeFalsy()
+  })
 
   test('combine pages from multiplee books (start to end)', async () => {
-    const merger = new PDFMerger();
-    const tmpFile = 'MergeDemo2.pdf';
+    const merger = new PDFMerger()
+    const tmpFile = 'MergeDemo2.pdf'
 
     await merger.add(
       await fs.readFile(path.join(FIXTURES_DIR, 'Testfile_AB.pdf')),
       [1]
-    );
+    )
     await merger.add(
       await fs.readFile(path.join(FIXTURES_DIR, 'UDHR.pdf')),
       '1 to 3'
-    );
+    )
 
-    const buffer = await merger.saveAsBuffer();
+    const buffer = await merger.saveAsBuffer()
     // Write the buffer as a file for pdfDiff
-    await fs.writeFile(path.join(TMP_DIR, tmpFile), buffer);
+    await fs.writeFile(path.join(TMP_DIR, tmpFile), buffer)
 
     const diff = await pdfDiff(
       path.join(FIXTURES_DIR, 'MergeDemo.pdf'),
       path.join(TMP_DIR, tmpFile)
-    );
+    )
 
-    expect(diff).toBeFalsy();
-  });
+    expect(diff).toBeFalsy()
+  })
 
   afterAll(async () => {
-    await fs.remove(TMP_DIR);
-  });
-});
+    await fs.remove(TMP_DIR)
+  })
+})

--- a/test/browser-fixtures.test.js
+++ b/test/browser-fixtures.test.js
@@ -1,54 +1,54 @@
-const path = require("path");
-const fs = require("fs-extra");
-const pdfDiff = require("pdf-diff");
+const path = require('path');
+const fs = require('fs-extra');
+const pdfDiff = require('pdf-diff');
 
-const PDFMerger = require("../browser");
+const PDFMerger = require('../browser');
 
-const FIXTURES_DIR = path.join(__dirname, "fixtures");
-const TMP_DIR = path.join(__dirname, "tmp");
+const FIXTURES_DIR = path.join(__dirname, 'fixtures');
+const TMP_DIR = path.join(__dirname, 'tmp');
 
 jest.setTimeout(10000);
 
 // Note: The browser tests differ from standard as all files are expected
 // to be generated or fetched before being passed into the merger.
 // For testing, they are retrieved with fs.ReadFile() and then passed in.
-describe("PDFMerger", () => {
+describe('PDFMerger', () => {
   beforeAll(async () => {
     await fs.ensureDir(TMP_DIR);
   });
 
-  test("merge two simple files", async () => {
+  test('merge two simple files', async () => {
     const merger = new PDFMerger();
 
     await merger.add(
-      await fs.readFile(path.join(FIXTURES_DIR, "Testfile_A.pdf"))
+      await fs.readFile(path.join(FIXTURES_DIR, 'Testfile_A.pdf'))
     );
     await merger.add(
-      await fs.readFile(path.join(FIXTURES_DIR, "Testfile_B.pdf"))
+      await fs.readFile(path.join(FIXTURES_DIR, 'Testfile_B.pdf'))
     );
 
     const buffer = await merger.saveAsBuffer();
     // Write the buffer as a file for pdfDiff
-    await fs.writeFile(path.join(TMP_DIR, "Testfile_AB.pdf"), buffer);
+    await fs.writeFile(path.join(TMP_DIR, 'Testfile_AB.pdf'), buffer);
 
     const diff = await pdfDiff(
-      path.join(FIXTURES_DIR, "Testfile_AB.pdf"),
-      path.join(TMP_DIR, "Testfile_AB.pdf")
+      path.join(FIXTURES_DIR, 'Testfile_AB.pdf'),
+      path.join(TMP_DIR, 'Testfile_AB.pdf')
     );
 
     expect(diff).toBeFalsy();
   });
 
-  test("combine pages from multiple books (array)", async () => {
+  test('combine pages from multiple books (array)', async () => {
     const merger = new PDFMerger();
-    const tmpFile = "MergeDemo1.pdf";
+    const tmpFile = 'MergeDemo1.pdf';
 
     await merger.add(
-      await fs.readFile(path.join(FIXTURES_DIR, "Testfile_AB.pdf")),
+      await fs.readFile(path.join(FIXTURES_DIR, 'Testfile_AB.pdf')),
       [1]
     );
     await merger.add(
-      await fs.readFile(path.join(FIXTURES_DIR, "UDHR.pdf")),
+      await fs.readFile(path.join(FIXTURES_DIR, 'UDHR.pdf')),
       [1, 2, 3]
     );
 
@@ -57,24 +57,24 @@ describe("PDFMerger", () => {
     await fs.writeFile(path.join(TMP_DIR, tmpFile), buffer);
 
     const diff = await pdfDiff(
-      path.join(FIXTURES_DIR, "MergeDemo.pdf"),
+      path.join(FIXTURES_DIR, 'MergeDemo.pdf'),
       path.join(TMP_DIR, tmpFile)
     );
 
     expect(diff).toBeFalsy();
   });
 
-  test("combine pages from multiple books (start-end)", async () => {
+  test('combine pages from multiple books (start-end)', async () => {
     const merger = new PDFMerger();
-    const tmpFile = "MergeDemo2.pdf";
+    const tmpFile = 'MergeDemo2.pdf';
 
     await merger.add(
-      await fs.readFile(path.join(FIXTURES_DIR, "Testfile_AB.pdf")),
+      await fs.readFile(path.join(FIXTURES_DIR, 'Testfile_AB.pdf')),
       [1]
     );
     await merger.add(
-      await fs.readFile(path.join(FIXTURES_DIR, "UDHR.pdf")),
-      "1-3"
+      await fs.readFile(path.join(FIXTURES_DIR, 'UDHR.pdf')),
+      '1-3'
     );
 
     const buffer = await merger.saveAsBuffer();
@@ -82,24 +82,24 @@ describe("PDFMerger", () => {
     await fs.writeFile(path.join(TMP_DIR, tmpFile), buffer);
 
     const diff = await pdfDiff(
-      path.join(FIXTURES_DIR, "MergeDemo.pdf"),
+      path.join(FIXTURES_DIR, 'MergeDemo.pdf'),
       path.join(TMP_DIR, tmpFile)
     );
 
     expect(diff).toBeFalsy();
   });
 
-  test("combine pages from multiple books (start - end)", async () => {
+  test('combine pages from multiple books (start - end)', async () => {
     const merger = new PDFMerger();
-    const tmpFile = "MergeDemo2.pdf";
+    const tmpFile = 'MergeDemo2.pdf';
 
     await merger.add(
-      await fs.readFile(path.join(FIXTURES_DIR, "Testfile_AB.pdf")),
+      await fs.readFile(path.join(FIXTURES_DIR, 'Testfile_AB.pdf')),
       [1]
     );
     await merger.add(
-      await fs.readFile(path.join(FIXTURES_DIR, "UDHR.pdf")),
-      "1 - 3"
+      await fs.readFile(path.join(FIXTURES_DIR, 'UDHR.pdf')),
+      '1 - 3'
     );
 
     const buffer = await merger.saveAsBuffer();
@@ -107,24 +107,24 @@ describe("PDFMerger", () => {
     await fs.writeFile(path.join(TMP_DIR, tmpFile), buffer);
 
     const diff = await pdfDiff(
-      path.join(FIXTURES_DIR, "MergeDemo.pdf"),
+      path.join(FIXTURES_DIR, 'MergeDemo.pdf'),
       path.join(TMP_DIR, tmpFile)
     );
 
     expect(diff).toBeFalsy();
   });
 
-  test("combine pages from multiplee books (start to end)", async () => {
+  test('combine pages from multiplee books (start to end)', async () => {
     const merger = new PDFMerger();
-    const tmpFile = "MergeDemo2.pdf";
+    const tmpFile = 'MergeDemo2.pdf';
 
     await merger.add(
-      await fs.readFile(path.join(FIXTURES_DIR, "Testfile_AB.pdf")),
+      await fs.readFile(path.join(FIXTURES_DIR, 'Testfile_AB.pdf')),
       [1]
     );
     await merger.add(
-      await fs.readFile(path.join(FIXTURES_DIR, "UDHR.pdf")),
-      "1 to 3"
+      await fs.readFile(path.join(FIXTURES_DIR, 'UDHR.pdf')),
+      '1 to 3'
     );
 
     const buffer = await merger.saveAsBuffer();
@@ -132,7 +132,7 @@ describe("PDFMerger", () => {
     await fs.writeFile(path.join(TMP_DIR, tmpFile), buffer);
 
     const diff = await pdfDiff(
-      path.join(FIXTURES_DIR, "MergeDemo.pdf"),
+      path.join(FIXTURES_DIR, 'MergeDemo.pdf'),
       path.join(TMP_DIR, tmpFile)
     );
 

--- a/test/browser-fixtures.test.js
+++ b/test/browser-fixtures.test.js
@@ -1,0 +1,145 @@
+const path = require("path");
+const fs = require("fs-extra");
+const pdfDiff = require("pdf-diff");
+
+const PDFMerger = require("../browser");
+
+const FIXTURES_DIR = path.join(__dirname, "fixtures");
+const TMP_DIR = path.join(__dirname, "tmp");
+
+jest.setTimeout(10000);
+
+// Note: The browser tests differ from standard as all files are expected
+// to be generated or fetched before being passed into the merger.
+// For testing, they are retrieved with fs.ReadFile() and then passed in.
+describe("PDFMerger", () => {
+  beforeAll(async () => {
+    await fs.ensureDir(TMP_DIR);
+  });
+
+  test("merge two simple files", async () => {
+    const merger = new PDFMerger();
+
+    await merger.add(
+      await fs.readFile(path.join(FIXTURES_DIR, "Testfile_A.pdf"))
+    );
+    await merger.add(
+      await fs.readFile(path.join(FIXTURES_DIR, "Testfile_B.pdf"))
+    );
+
+    const buffer = await merger.saveAsBuffer();
+    // Write the buffer as a file for pdfDiff
+    await fs.writeFile(path.join(TMP_DIR, "Testfile_AB.pdf"), buffer);
+
+    const diff = await pdfDiff(
+      path.join(FIXTURES_DIR, "Testfile_AB.pdf"),
+      path.join(TMP_DIR, "Testfile_AB.pdf")
+    );
+
+    expect(diff).toBeFalsy();
+  });
+
+  test("combine pages from multiple books (array)", async () => {
+    const merger = new PDFMerger();
+    const tmpFile = "MergeDemo1.pdf";
+
+    await merger.add(
+      await fs.readFile(path.join(FIXTURES_DIR, "Testfile_AB.pdf")),
+      [1]
+    );
+    await merger.add(
+      await fs.readFile(path.join(FIXTURES_DIR, "UDHR.pdf")),
+      [1, 2, 3]
+    );
+
+    const buffer = await merger.saveAsBuffer();
+    // Write the buffer as a file for pdfDiff
+    await fs.writeFile(path.join(TMP_DIR, tmpFile), buffer);
+
+    const diff = await pdfDiff(
+      path.join(FIXTURES_DIR, "MergeDemo.pdf"),
+      path.join(TMP_DIR, tmpFile)
+    );
+
+    expect(diff).toBeFalsy();
+  });
+
+  test("combine pages from multiple books (start-end)", async () => {
+    const merger = new PDFMerger();
+    const tmpFile = "MergeDemo2.pdf";
+
+    await merger.add(
+      await fs.readFile(path.join(FIXTURES_DIR, "Testfile_AB.pdf")),
+      [1]
+    );
+    await merger.add(
+      await fs.readFile(path.join(FIXTURES_DIR, "UDHR.pdf")),
+      "1-3"
+    );
+
+    const buffer = await merger.saveAsBuffer();
+    // Write the buffer as a file for pdfDiff
+    await fs.writeFile(path.join(TMP_DIR, tmpFile), buffer);
+
+    const diff = await pdfDiff(
+      path.join(FIXTURES_DIR, "MergeDemo.pdf"),
+      path.join(TMP_DIR, tmpFile)
+    );
+
+    expect(diff).toBeFalsy();
+  });
+
+  test("combine pages from multiple books (start - end)", async () => {
+    const merger = new PDFMerger();
+    const tmpFile = "MergeDemo2.pdf";
+
+    await merger.add(
+      await fs.readFile(path.join(FIXTURES_DIR, "Testfile_AB.pdf")),
+      [1]
+    );
+    await merger.add(
+      await fs.readFile(path.join(FIXTURES_DIR, "UDHR.pdf")),
+      "1 - 3"
+    );
+
+    const buffer = await merger.saveAsBuffer();
+    // Write the buffer as a file for pdfDiff
+    await fs.writeFile(path.join(TMP_DIR, tmpFile), buffer);
+
+    const diff = await pdfDiff(
+      path.join(FIXTURES_DIR, "MergeDemo.pdf"),
+      path.join(TMP_DIR, tmpFile)
+    );
+
+    expect(diff).toBeFalsy();
+  });
+
+  test("combine pages from multiplee books (start to end)", async () => {
+    const merger = new PDFMerger();
+    const tmpFile = "MergeDemo2.pdf";
+
+    await merger.add(
+      await fs.readFile(path.join(FIXTURES_DIR, "Testfile_AB.pdf")),
+      [1]
+    );
+    await merger.add(
+      await fs.readFile(path.join(FIXTURES_DIR, "UDHR.pdf")),
+      "1 to 3"
+    );
+
+    const buffer = await merger.saveAsBuffer();
+    // Write the buffer as a file for pdfDiff
+    await fs.writeFile(path.join(TMP_DIR, tmpFile), buffer);
+
+    const diff = await pdfDiff(
+      path.join(FIXTURES_DIR, "MergeDemo.pdf"),
+      path.join(TMP_DIR, tmpFile)
+    );
+
+    expect(diff).toBeFalsy();
+  });
+
+  afterAll(async () => {
+    await fs.remove(TMP_DIR);
+  });
+});

--- a/test/fixtures.test.js
+++ b/test/fixtures.test.js
@@ -1,94 +1,94 @@
-const path = require('path')
-const fs = require('fs-extra')
-const pdfDiff = require('pdf-diff')
+const path = require("path");
+const fs = require("fs-extra");
+const pdfDiff = require("pdf-diff");
 
-const PDFMerger = require('../index')
+const PDFMerger = require("../index");
 
-const FIXTURES_DIR = path.join(__dirname, 'fixtures')
-const TMP_DIR = path.join(__dirname, 'tmp')
+const FIXTURES_DIR = path.join(__dirname, "fixtures");
+const TMP_DIR = path.join(__dirname, "tmp");
 
-jest.setTimeout(10000)
+jest.setTimeout(10000);
 
-describe('PDFMerger', () => {
+describe("PDFMerger", () => {
   beforeAll(async () => {
-    await fs.ensureDir(TMP_DIR)
-  })
+    await fs.ensureDir(TMP_DIR);
+  });
 
-  test('merge two simple files', async () => {
-    const merger = new PDFMerger()
-    merger.add(path.join(FIXTURES_DIR, 'Testfile_A.pdf'))
-    merger.add(path.join(FIXTURES_DIR, 'Testfile_B.pdf'))
-    await merger.save(path.join(TMP_DIR, 'Testfile_AB.pdf'))
-
-    const diff = await pdfDiff(
-      path.join(FIXTURES_DIR, 'Testfile_AB.pdf'),
-      path.join(TMP_DIR, 'Testfile_AB.pdf')
-    )
-
-    expect(diff).toBeFalsy()
-  })
-
-  test('combine pages from multibe books (array)', async () => {
-    const merger = new PDFMerger()
-    const tmpFile = 'MergeDemo1.pdf'
-    merger.add(path.join(FIXTURES_DIR, 'Testfile_AB.pdf'), [1])
-    merger.add(path.join(FIXTURES_DIR, 'UDHR.pdf'), [1, 2, 3])
-    await merger.save(path.join(TMP_DIR, tmpFile))
+  test("merge two simple files", async () => {
+    const merger = new PDFMerger();
+    merger.add(path.join(FIXTURES_DIR, "Testfile_A.pdf"));
+    merger.add(path.join(FIXTURES_DIR, "Testfile_B.pdf"));
+    await merger.save(path.join(TMP_DIR, "Testfile_AB.pdf"));
 
     const diff = await pdfDiff(
-      path.join(FIXTURES_DIR, 'MergeDemo.pdf'),
+      path.join(FIXTURES_DIR, "Testfile_AB.pdf"),
+      path.join(TMP_DIR, "Testfile_AB.pdf")
+    );
+
+    expect(diff).toBeFalsy();
+  });
+
+  test("combine pages from multibe books (array)", async () => {
+    const merger = new PDFMerger();
+    const tmpFile = "MergeDemo1.pdf";
+    merger.add(path.join(FIXTURES_DIR, "Testfile_AB.pdf"), [1]);
+    merger.add(path.join(FIXTURES_DIR, "UDHR.pdf"), [1, 2, 3]);
+    await merger.save(path.join(TMP_DIR, tmpFile));
+
+    const diff = await pdfDiff(
+      path.join(FIXTURES_DIR, "MergeDemo.pdf"),
       path.join(TMP_DIR, tmpFile)
-    )
+    );
 
-    expect(diff).toBeFalsy()
-  })
+    expect(diff).toBeFalsy();
+  });
 
-  test('combine pages from multibe books (start-end)', async () => {
-    const merger = new PDFMerger()
-    const tmpFile = 'MergeDemo2.pdf'
-    merger.add(path.join(FIXTURES_DIR, 'Testfile_AB.pdf'), [1])
-    merger.add(path.join(FIXTURES_DIR, 'UDHR.pdf'), '1-3')
-    await merger.save(path.join(TMP_DIR, tmpFile))
-
-    const diff = await pdfDiff(
-      path.join(FIXTURES_DIR, 'MergeDemo.pdf'),
-      path.join(TMP_DIR, tmpFile)
-    )
-
-    expect(diff).toBeFalsy()
-  })
-
-  test('combine pages from multibe books (start - end)', async () => {
-    const merger = new PDFMerger()
-    const tmpFile = 'MergeDemo2.pdf'
-    merger.add(path.join(FIXTURES_DIR, 'Testfile_AB.pdf'), [1])
-    merger.add(path.join(FIXTURES_DIR, 'UDHR.pdf'), '1 - 3')
-    await merger.save(path.join(TMP_DIR, tmpFile))
+  test("combine pages from multibe books (start-end)", async () => {
+    const merger = new PDFMerger();
+    const tmpFile = "MergeDemo2.pdf";
+    merger.add(path.join(FIXTURES_DIR, "Testfile_AB.pdf"), [1]);
+    merger.add(path.join(FIXTURES_DIR, "UDHR.pdf"), "1-3");
+    await merger.save(path.join(TMP_DIR, tmpFile));
 
     const diff = await pdfDiff(
-      path.join(FIXTURES_DIR, 'MergeDemo.pdf'),
+      path.join(FIXTURES_DIR, "MergeDemo.pdf"),
       path.join(TMP_DIR, tmpFile)
-    )
+    );
 
-    expect(diff).toBeFalsy()
-  })
+    expect(diff).toBeFalsy();
+  });
 
-  test('combine pages from multibe books (start to end)', async () => {
-    const merger = new PDFMerger()
-    const tmpFile = 'MergeDemo2.pdf'
-    merger.add(path.join(FIXTURES_DIR, 'Testfile_AB.pdf'), [1])
-    merger.add(path.join(FIXTURES_DIR, 'UDHR.pdf'), '1 to 3')
-    await merger.save(path.join(TMP_DIR, tmpFile))
+  test("combine pages from multibe books (start - end)", async () => {
+    const merger = new PDFMerger();
+    const tmpFile = "MergeDemo2.pdf";
+    merger.add(path.join(FIXTURES_DIR, "Testfile_AB.pdf"), [1]);
+    merger.add(path.join(FIXTURES_DIR, "UDHR.pdf"), "1 - 3");
+    await merger.save(path.join(TMP_DIR, tmpFile));
 
     const diff = await pdfDiff(
-      path.join(FIXTURES_DIR, 'MergeDemo.pdf'),
+      path.join(FIXTURES_DIR, "MergeDemo.pdf"),
       path.join(TMP_DIR, tmpFile)
-    )
+    );
 
-    expect(diff).toBeFalsy()
-  })
+    expect(diff).toBeFalsy();
+  });
+
+  test("combine pages from multibe books (start to end)", async () => {
+    const merger = new PDFMerger();
+    const tmpFile = "MergeDemo2.pdf";
+    merger.add(path.join(FIXTURES_DIR, "Testfile_AB.pdf"), [1]);
+    merger.add(path.join(FIXTURES_DIR, "UDHR.pdf"), "1 to 3");
+    await merger.save(path.join(TMP_DIR, tmpFile));
+
+    const diff = await pdfDiff(
+      path.join(FIXTURES_DIR, "MergeDemo.pdf"),
+      path.join(TMP_DIR, tmpFile)
+    );
+
+    expect(diff).toBeFalsy();
+  });
 
   afterAll(async () => {
-    await fs.remove(TMP_DIR)
-  })
-})
+    await fs.remove(TMP_DIR);
+  });
+});

--- a/test/fixtures.test.js
+++ b/test/fixtures.test.js
@@ -1,94 +1,94 @@
-const path = require("path");
-const fs = require("fs-extra");
-const pdfDiff = require("pdf-diff");
+const path = require('path')
+const fs = require('fs-extra')
+const pdfDiff = require('pdf-diff')
 
-const PDFMerger = require("../index");
+const PDFMerger = require('../index')
 
-const FIXTURES_DIR = path.join(__dirname, "fixtures");
-const TMP_DIR = path.join(__dirname, "tmp");
+const FIXTURES_DIR = path.join(__dirname, 'fixtures')
+const TMP_DIR = path.join(__dirname, 'tmp')
 
-jest.setTimeout(10000);
+jest.setTimeout(10000)
 
-describe("PDFMerger", () => {
+describe('PDFMerger', () => {
   beforeAll(async () => {
-    await fs.ensureDir(TMP_DIR);
-  });
+    await fs.ensureDir(TMP_DIR)
+  })
 
-  test("merge two simple files", async () => {
-    const merger = new PDFMerger();
-    merger.add(path.join(FIXTURES_DIR, "Testfile_A.pdf"));
-    merger.add(path.join(FIXTURES_DIR, "Testfile_B.pdf"));
-    await merger.save(path.join(TMP_DIR, "Testfile_AB.pdf"));
-
-    const diff = await pdfDiff(
-      path.join(FIXTURES_DIR, "Testfile_AB.pdf"),
-      path.join(TMP_DIR, "Testfile_AB.pdf")
-    );
-
-    expect(diff).toBeFalsy();
-  });
-
-  test("combine pages from multibe books (array)", async () => {
-    const merger = new PDFMerger();
-    const tmpFile = "MergeDemo1.pdf";
-    merger.add(path.join(FIXTURES_DIR, "Testfile_AB.pdf"), [1]);
-    merger.add(path.join(FIXTURES_DIR, "UDHR.pdf"), [1, 2, 3]);
-    await merger.save(path.join(TMP_DIR, tmpFile));
+  test('merge two simple files', async () => {
+    const merger = new PDFMerger()
+    merger.add(path.join(FIXTURES_DIR, 'Testfile_A.pdf'))
+    merger.add(path.join(FIXTURES_DIR, 'Testfile_B.pdf'))
+    await merger.save(path.join(TMP_DIR, 'Testfile_AB.pdf'))
 
     const diff = await pdfDiff(
-      path.join(FIXTURES_DIR, "MergeDemo.pdf"),
+      path.join(FIXTURES_DIR, 'Testfile_AB.pdf'),
+      path.join(TMP_DIR, 'Testfile_AB.pdf')
+    )
+
+    expect(diff).toBeFalsy()
+  })
+
+  test('combine pages from multibe books (array)', async () => {
+    const merger = new PDFMerger()
+    const tmpFile = 'MergeDemo1.pdf'
+    merger.add(path.join(FIXTURES_DIR, 'Testfile_AB.pdf'), [1])
+    merger.add(path.join(FIXTURES_DIR, 'UDHR.pdf'), [1, 2, 3])
+    await merger.save(path.join(TMP_DIR, tmpFile))
+
+    const diff = await pdfDiff(
+      path.join(FIXTURES_DIR, 'MergeDemo.pdf'),
       path.join(TMP_DIR, tmpFile)
-    );
+    )
 
-    expect(diff).toBeFalsy();
-  });
+    expect(diff).toBeFalsy()
+  })
 
-  test("combine pages from multibe books (start-end)", async () => {
-    const merger = new PDFMerger();
-    const tmpFile = "MergeDemo2.pdf";
-    merger.add(path.join(FIXTURES_DIR, "Testfile_AB.pdf"), [1]);
-    merger.add(path.join(FIXTURES_DIR, "UDHR.pdf"), "1-3");
-    await merger.save(path.join(TMP_DIR, tmpFile));
-
-    const diff = await pdfDiff(
-      path.join(FIXTURES_DIR, "MergeDemo.pdf"),
-      path.join(TMP_DIR, tmpFile)
-    );
-
-    expect(diff).toBeFalsy();
-  });
-
-  test("combine pages from multibe books (start - end)", async () => {
-    const merger = new PDFMerger();
-    const tmpFile = "MergeDemo2.pdf";
-    merger.add(path.join(FIXTURES_DIR, "Testfile_AB.pdf"), [1]);
-    merger.add(path.join(FIXTURES_DIR, "UDHR.pdf"), "1 - 3");
-    await merger.save(path.join(TMP_DIR, tmpFile));
+  test('combine pages from multibe books (start-end)', async () => {
+    const merger = new PDFMerger()
+    const tmpFile = 'MergeDemo2.pdf'
+    merger.add(path.join(FIXTURES_DIR, 'Testfile_AB.pdf'), [1])
+    merger.add(path.join(FIXTURES_DIR, 'UDHR.pdf'), '1-3')
+    await merger.save(path.join(TMP_DIR, tmpFile))
 
     const diff = await pdfDiff(
-      path.join(FIXTURES_DIR, "MergeDemo.pdf"),
+      path.join(FIXTURES_DIR, 'MergeDemo.pdf'),
       path.join(TMP_DIR, tmpFile)
-    );
+    )
 
-    expect(diff).toBeFalsy();
-  });
+    expect(diff).toBeFalsy()
+  })
 
-  test("combine pages from multibe books (start to end)", async () => {
-    const merger = new PDFMerger();
-    const tmpFile = "MergeDemo2.pdf";
-    merger.add(path.join(FIXTURES_DIR, "Testfile_AB.pdf"), [1]);
-    merger.add(path.join(FIXTURES_DIR, "UDHR.pdf"), "1 to 3");
-    await merger.save(path.join(TMP_DIR, tmpFile));
+  test('combine pages from multibe books (start - end)', async () => {
+    const merger = new PDFMerger()
+    const tmpFile = 'MergeDemo2.pdf'
+    merger.add(path.join(FIXTURES_DIR, 'Testfile_AB.pdf'), [1])
+    merger.add(path.join(FIXTURES_DIR, 'UDHR.pdf'), '1 - 3')
+    await merger.save(path.join(TMP_DIR, tmpFile))
 
     const diff = await pdfDiff(
-      path.join(FIXTURES_DIR, "MergeDemo.pdf"),
+      path.join(FIXTURES_DIR, 'MergeDemo.pdf'),
       path.join(TMP_DIR, tmpFile)
-    );
+    )
 
-    expect(diff).toBeFalsy();
-  });
+    expect(diff).toBeFalsy()
+  })
+
+  test('combine pages from multibe books (start to end)', async () => {
+    const merger = new PDFMerger()
+    const tmpFile = 'MergeDemo2.pdf'
+    merger.add(path.join(FIXTURES_DIR, 'Testfile_AB.pdf'), [1])
+    merger.add(path.join(FIXTURES_DIR, 'UDHR.pdf'), '1 to 3')
+    await merger.save(path.join(TMP_DIR, tmpFile))
+
+    const diff = await pdfDiff(
+      path.join(FIXTURES_DIR, 'MergeDemo.pdf'),
+      path.join(TMP_DIR, tmpFile)
+    )
+
+    expect(diff).toBeFalsy()
+  })
 
   afterAll(async () => {
-    await fs.remove(TMP_DIR);
-  });
-});
+    await fs.remove(TMP_DIR)
+  })
+})


### PR DESCRIPTION
### Summary

Creates a browser compatible version of the library by replacing fs with [FileReader API](https://developer.mozilla.org/en-US/docs/Web/API/FileReader) and Promises/async.

This also allows Promise.all and Promise.allSettled to be used when mapping over and adding several PDFs.

Adds the below simple example to README.

### Usage

```javascript
import PDFMerger from "pdf-merger-js/browser-promises";
import React, { useEffect, useState } from "react";

// files: Array of PDF File or Blob objects
const Merger = (files) => {
  const [mergedPdfUrl, setMergedPdfUrl] = useState();

  useEffect(() => {
    const render = async () => {
      const merger = new PDFMerger();

      await Promise.all(files.map(async (file) => await merger.add(file)));

      const mergedPdf = await merger.saveAsBlob();
      const url = URL.createObjectURL(mergedPdf);

      return setMergedPdfUrl(url);
    };

    render().catch((err) => {
      throw err;
    });

    () => setMergedPdfUrl({});
  }, [files, setMergedPdfUrl]);

  return !data ? (
    <>Loading</>
  ) : (
    <iframe
      height={1000}
      src={`${mergedPdfUrl}`}
      title="pdf-viewer"
      width="100%s"
    ></iframe>
  );
};
```

### Closing Comments

This will allow for merging PDFs on the frontend in cases where the resource use is acceptable or preferred vs performing the task on a backend api. The returned merged pdf can be displayed, downloaded, or uploaded later.

Further possible improvements: use Fetch instead of FileReader when a url is passed in instead of a Blob.

---
*implements #17* 