### PR TITLE
Browser: Add fetch for urls

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -39,23 +39,12 @@ class PDFMerger {
   }
 
   async _getInputFile (inputFile) {
-    return new Promise(async (resolve) => {
+    return new Promise((resolve) => {
       if (inputFile instanceof Buffer || inputFile instanceof ArrayBuffer) {
         resolve(inputFile)
-      }
-      else if (typeof(inputFile) === 'string' || inputFile instanceof String) {
-        // Check if valid url before attempting to fetch
-        // http, https, blob, and data urls will pass this but so will javascript:xxxx
-        try {
-          new URL(inputFile)
-        } catch {
-          throw new Error(`string ${inputFile} is not a valid url`);
-        }
-        
-        const file = await (await fetch(inputFile)).arrayBuffer()
-        resolve(file)
-      }
-      else if (inputFile instanceof File || inputFile instanceof Blob) {
+      } else if (typeof inputFile === 'string' || inputFile instanceof String) {
+        window.fetch(inputFile).then(res => res.arrayBuffer()).then(resolve)
+      } else if (inputFile instanceof window.File || inputFile instanceof window.Blob) {
         const fileReader = new window.FileReader()
 
         fileReader.onload = function (evt) {
@@ -63,9 +52,8 @@ class PDFMerger {
         }
 
         fileReader.readAsArrayBuffer(inputFile)
-      }
-      else {
-        throw new Error("pdf must be represented as a Buffer, Url, File, or Blob")
+      } else {
+        throw new Error('pdf must be represented as a Buffer, Url, File, or Blob')
       }
     })
   }

--- a/browser.js
+++ b/browser.js
@@ -39,29 +39,29 @@ class PDFMerger {
   }
 
   async _getInputFile (inputFile) {
-      if (inputFile instanceof Buffer || inputFile instanceof ArrayBuffer) {
-        return inputFile
-      }
-      if (typeof inputFile === 'string' || inputFile instanceof String) {
-        const res = await window.fetch(inputFile)
-        const ab = await res.arrayBuffer()
-        return ab
-      }
-      if (inputFile instanceof window.File) {
-        const fileReader = new window.FileReader()
+    if (inputFile instanceof Buffer || inputFile instanceof ArrayBuffer) {
+      return inputFile
+    }
+    if (typeof inputFile === 'string' || inputFile instanceof String) {
+      const res = await window.fetch(inputFile)
+      const ab = await res.arrayBuffer()
+      return ab
+    }
+    if (inputFile instanceof window.File) {
+      const fileReader = new window.FileReader()
 
-        fileReader.onload = function (evt) {
-          return fileReader.result
-        }
-
-        fileReader.readAsArrayBuffer(inputFile)
+      fileReader.onload = function (evt) {
+        return fileReader.result
       }
 
-      if (inputFile instanceof window.Blob) {
-        return await inputFile.arrayBuffer()
-      }
+      fileReader.readAsArrayBuffer(inputFile)
+    }
 
-      throw new Error('pdf must be represented as an ArrayBuffer, Blob, Buffer, File, or URL')
+    if (inputFile instanceof window.Blob) {
+      return await inputFile.arrayBuffer()
+    }
+
+    throw new Error('pdf must be represented as an ArrayBuffer, Blob, Buffer, File, or URL')
   }
 
   async _addEntireDocument (inputFile) {

--- a/browser.js
+++ b/browser.js
@@ -5,7 +5,7 @@ class PDFMerger {
     this._resetDoc()
   }
 
-  add (inputFile, pages) {
+  async add (inputFile, pages) {
     if (typeof pages === 'undefined' || pages === null) {
       return this._addEntireDocument(inputFile, pages)
     } else if (Array.isArray(pages)) {
@@ -39,23 +39,23 @@ class PDFMerger {
   }
 
   async _getInputFile (inputFile) {
-    return new Promise((resolve) => {
       if (inputFile instanceof Buffer || inputFile instanceof ArrayBuffer) {
-        resolve(inputFile)
+        return inputFile
       } else if (typeof inputFile === 'string' || inputFile instanceof String) {
-        window.fetch(inputFile).then(res => res.arrayBuffer()).then(resolve)
+        const res = await window.fetch(inputFile)
+        const ab = await res.arrayBuffer()
+        return ab
       } else if (inputFile instanceof window.File || inputFile instanceof window.Blob) {
         const fileReader = new window.FileReader()
 
         fileReader.onload = function (evt) {
-          resolve(fileReader.result)
+          return fileReader.result
         }
 
         fileReader.readAsArrayBuffer(inputFile)
       } else {
         throw new Error('pdf must be represented as an ArrayBuffer, Blob, Buffer, File, or URL')
       }
-    })
   }
 
   async _addEntireDocument (inputFile) {

--- a/browser.js
+++ b/browser.js
@@ -41,11 +41,13 @@ class PDFMerger {
   async _getInputFile (inputFile) {
       if (inputFile instanceof Buffer || inputFile instanceof ArrayBuffer) {
         return inputFile
-      } else if (typeof inputFile === 'string' || inputFile instanceof String) {
+      }
+      if (typeof inputFile === 'string' || inputFile instanceof String) {
         const res = await window.fetch(inputFile)
         const ab = await res.arrayBuffer()
         return ab
-      } else if (inputFile instanceof window.File || inputFile instanceof window.Blob) {
+      }
+      if (inputFile instanceof window.File) {
         const fileReader = new window.FileReader()
 
         fileReader.onload = function (evt) {
@@ -53,9 +55,13 @@ class PDFMerger {
         }
 
         fileReader.readAsArrayBuffer(inputFile)
-      } else {
-        throw new Error('pdf must be represented as an ArrayBuffer, Blob, Buffer, File, or URL')
       }
+
+      if (inputFile instanceof window.Blob) {
+        return await inputFile.arrayBuffer()
+      }
+
+      throw new Error('pdf must be represented as an ArrayBuffer, Blob, Buffer, File, or URL')
   }
 
   async _addEntireDocument (inputFile) {

--- a/browser.js
+++ b/browser.js
@@ -53,7 +53,7 @@ class PDFMerger {
 
         fileReader.readAsArrayBuffer(inputFile)
       } else {
-        throw new Error('pdf must be represented as a Buffer, Url, File, or Blob')
+        throw new Error('pdf must be represented as an ArrayBuffer, Blob, Buffer, File, or URL')
       }
     })
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -2864,28 +2864,6 @@
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
       "dev": true
     },
-    "isobject": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-      "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-      "dev": true
-    },
-    "isomorphic-fetch": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-3.0.0.tgz",
-      "integrity": "sha512-qvUtwJ3j6qwsF3jLxkZ72qCgjMysPzDfeV240JHiGZsANBYd+EEuu35v7dfrJ9Up0Ak07D7GGSkGhCHTqg/5wA==",
-      "dev": true,
-      "requires": {
-        "node-fetch": "^2.6.1",
-        "whatwg-fetch": "^3.4.1"
-      }
-    },
-    "isstream": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
-      "dev": true
-    },
     "istanbul-lib-coverage": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.0.0.tgz",
@@ -3448,9 +3426,9 @@
       }
     },
     "jsdom": {
-      "version": "16.6.0",
-      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-16.6.0.tgz",
-      "integrity": "sha512-Ty1vmF4NHJkolaEmdjtxTfSfkdb8Ywarwf63f+F8/mDD1uLSSWDxDuMiZxiPhwunLrn9LOSVItWj4bLYsLN3Dg==",
+      "version": "16.7.0",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-16.7.0.tgz",
+      "integrity": "sha512-u9Smc2G1USStM+s/x1ru5Sxrl6mPYCbByG1U/hUmqaVsm4tbNyS7CicOSRyuGQYZhTu0h84qkZZQ/I+dzizSVw==",
       "dev": true,
       "requires": {
         "abab": "^2.0.5",
@@ -3478,7 +3456,7 @@
         "whatwg-encoding": "^1.0.5",
         "whatwg-mimetype": "^2.3.0",
         "whatwg-url": "^8.5.0",
-        "ws": "^7.4.5",
+        "ws": "^7.4.6",
         "xml-name-validator": "^3.0.0"
       },
       "dependencies": {
@@ -3727,12 +3705,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
-      "dev": true
-    },
-    "nice-try": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
-      "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
       "dev": true
     },
     "node-fetch": {
@@ -5070,12 +5042,6 @@
       "requires": {
         "iconv-lite": "0.4.24"
       }
-    },
-    "whatwg-fetch": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.6.2.tgz",
-      "integrity": "sha512-bJlen0FcuU/0EMLrdbJ7zOnW6ITZLrZMIarMUVmdKtsGvZna8vxKYaexICWPfZ8qwf9fzNq+UEIZrnSaApt6RA==",
-      "dev": true
     },
     "whatwg-mimetype": {
       "version": "2.3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2864,6 +2864,28 @@
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
       "dev": true
     },
+    "isobject": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+      "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+      "dev": true
+    },
+    "isomorphic-fetch": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-3.0.0.tgz",
+      "integrity": "sha512-qvUtwJ3j6qwsF3jLxkZ72qCgjMysPzDfeV240JHiGZsANBYd+EEuu35v7dfrJ9Up0Ak07D7GGSkGhCHTqg/5wA==",
+      "dev": true,
+      "requires": {
+        "node-fetch": "^2.6.1",
+        "whatwg-fetch": "^3.4.1"
+      }
+    },
+    "isstream": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
+      "dev": true
+    },
     "istanbul-lib-coverage": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.0.0.tgz",
@@ -3705,6 +3727,18 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
+      "dev": true
+    },
+    "nice-try": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
+      "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
+      "dev": true
+    },
+    "node-fetch": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==",
       "dev": true
     },
     "node-int64": {
@@ -5036,6 +5070,12 @@
       "requires": {
         "iconv-lite": "0.4.24"
       }
+    },
+    "whatwg-fetch": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.6.2.tgz",
+      "integrity": "sha512-bJlen0FcuU/0EMLrdbJ7zOnW6ITZLrZMIarMUVmdKtsGvZna8vxKYaexICWPfZ8qwf9fzNq+UEIZrnSaApt6RA==",
+      "dev": true
     },
     "whatwg-mimetype": {
       "version": "2.3.0",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   "devDependencies": {
     "fs-extra": "^10.0.0",
     "jest": "^27.0.6",
+    "isomorphic-fetch": "^3.0.0",
     "pdf-diff": "^0.1.1",
     "standard": "^16.0.3"
   }

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
   "devDependencies": {
     "fs-extra": "^10.0.0",
     "jest": "^27.0.6",
-    "isomorphic-fetch": "^3.0.0",
+    "jsdom": "^16.7.0",
+    "node-fetch": "^2.6.1",
     "pdf-diff": "^0.1.1",
     "standard": "^16.0.3"
   }

--- a/test/browser-fixtures.test.js
+++ b/test/browser-fixtures.test.js
@@ -1,7 +1,7 @@
 const path = require('path')
 const fs = require('fs-extra')
 const pdfDiff = require('pdf-diff')
-global.fetch = require('isomorphic-fetch');
+global.fetch = require('isomorphic-fetch')
 
 const PDFMerger = require('../browser')
 
@@ -144,10 +144,10 @@ describe('PDFMerger', () => {
     const merger = new PDFMerger()
 
     await merger.add(
-      "https://github.com/nbesli/pdf-merger-js/raw/master/test/fixtures/Testfile_A.pdf"
+      'https://github.com/nbesli/pdf-merger-js/raw/master/test/fixtures/Testfile_A.pdf'
     )
     await merger.add(
-      "https://github.com/nbesli/pdf-merger-js/raw/master/test/fixtures/Testfile_B.pdf"
+      'https://github.com/nbesli/pdf-merger-js/raw/master/test/fixtures/Testfile_B.pdf'
     )
 
     const buffer = await merger.saveAsBuffer()

--- a/test/browser-fixtures.test.js
+++ b/test/browser-fixtures.test.js
@@ -1,168 +1,252 @@
-const path = require('path')
-const fs = require('fs-extra')
-const pdfDiff = require('pdf-diff')
-global.fetch = require('isomorphic-fetch')
+/**
+ * @jest-environment jsdom
+ */
 
-const PDFMerger = require('../browser')
+const path = require("path")
+const fs = require("fs-extra")
+const pdfDiff = require("pdf-diff")
+const url = require(`url`)
+/* 
+  add a global `windows.fetch` to mock fetch
+*/
+global.window.fetch = jest.fn().mockImplementation((requestUrl) => {
+  const URL = require("url").URL;
+  console.log(requestUrl)
+  try {
+    const url = new URL(requestUrl)
+    if (!["http:", "https:", "data-url:", "blob:"].includes(url.protocol)) {
+      throw TypeError
+    }
+  } catch {
+    throw new TypeError("Failed to Fetch")
+  }
+  if (requestUrl === `https://google.com`) {
+    throw new TypeError("Failed to Fetch")
+  }
+  return Promise.resolve({arrayBuffer: async() => fs.readFile(path.join(FIXTURES_DIR, "Testfile_A.pdf"))})
+  })
 
-const FIXTURES_DIR = path.join(__dirname, 'fixtures')
-const TMP_DIR = path.join(__dirname, 'tmp')
+const PDFMerger = require("../browser")
 
-jest.setTimeout(10000)
+const FIXTURES_DIR = path.join(__dirname, "fixtures")
+const TMP_DIR = path.join(__dirname, "tmp")
+
+jest.setTimeout(100000)
+
+let fileA = undefined
+let fileB = undefined
 
 // Note: The browser tests differ from standard as all files are expected
 // to be generated or fetched before being passed into the merger.
 // For testing, they are retrieved with fs.ReadFile() and then passed in.
-describe('PDFMerger', () => {
+describe("PDFMerger", () => {
   beforeAll(async () => {
     await fs.ensureDir(TMP_DIR)
+    fileA = await fs.readFile(path.join(FIXTURES_DIR, "Testfile_A.pdf"))
+    fileB = await fs.readFile(path.join(FIXTURES_DIR, "Testfile_B.pdf"))
   })
 
-  test('merge two simple files', async () => {
+  // describe("test successful merges", () => {
+  //   test("merge two simple files", async () => {
+  //     const merger = new PDFMerger()
+
+  //     await merger.add(fileA)
+  //     await merger.add(fileB)
+
+  //     const buffer = await merger.saveAsBuffer()
+  //     // Write the buffer as a file for pdfDiff
+  //     await fs.writeFile(path.join(TMP_DIR, "Testfile_AB.pdf"), buffer)
+
+  //     const diff = await pdfDiff(
+  //       path.join(FIXTURES_DIR, "Testfile_AB.pdf"),
+  //       path.join(TMP_DIR, "Testfile_AB.pdf")
+  //     )
+
+  //     expect(diff).toBeFalsy()
+  //   })
+
+  //   test("combine pages from multiple books (array)", async () => {
+  //     const merger = new PDFMerger()
+  //     const tmpFile = "MergeDemo1.pdf"
+
+  //     await merger.add(fileA, [1])
+  //     await merger.add(fileB, [1, 2, 3])
+
+  //     const buffer = await merger.saveAsBuffer()
+  //     // Write the buffer as a file for pdfDiff
+  //     await fs.writeFile(path.join(TMP_DIR, tmpFile), buffer)
+
+  //     const diff = await pdfDiff(
+  //       path.join(FIXTURES_DIR, "MergeDemo.pdf"),
+  //       path.join(TMP_DIR, tmpFile)
+  //     )
+
+  //     expect(diff).toBeFalsy()
+  //   })
+
+  //   test("combine pages from multiple books (start-end)", async () => {
+  //     const merger = new PDFMerger()
+  //     const tmpFile = "MergeDemo2.pdf"
+
+  //     await merger.add(
+  //       await fs.readFile(path.join(FIXTURES_DIR, "Testfile_AB.pdf")),
+  //       [1]
+  //     )
+  //     await merger.add(
+  //       await fs.readFile(path.join(FIXTURES_DIR, "UDHR.pdf")),
+  //       "1-3"
+  //     )
+
+  //     const buffer = await merger.saveAsBuffer()
+  //     // Write the buffer as a file for pdfDiff
+  //     await fs.writeFile(path.join(TMP_DIR, tmpFile), buffer)
+
+  //     const diff = await pdfDiff(
+  //       path.join(FIXTURES_DIR, "MergeDemo.pdf"),
+  //       path.join(TMP_DIR, tmpFile)
+  //     )
+
+  //     expect(diff).toBeFalsy()
+  //   })
+
+  //   test("combine pages from multiple books (start - end)", async () => {
+  //     const merger = new PDFMerger()
+  //     const tmpFile = "MergeDemo2.pdf"
+
+  //     await merger.add(
+  //       await fs.readFile(path.join(FIXTURES_DIR, "Testfile_AB.pdf")),
+  //       [1]
+  //     )
+  //     await merger.add(
+  //       await fs.readFile(path.join(FIXTURES_DIR, "UDHR.pdf")),
+  //       "1 - 3"
+  //     )
+
+  //     const buffer = await merger.saveAsBuffer()
+  //     // Write the buffer as a file for pdfDiff
+  //     await fs.writeFile(path.join(TMP_DIR, tmpFile), buffer)
+
+  //     const diff = await pdfDiff(
+  //       path.join(FIXTURES_DIR, "MergeDemo.pdf"),
+  //       path.join(TMP_DIR, tmpFile)
+  //     )
+
+  //     expect(diff).toBeFalsy()
+  //   })
+
+  //   test("combine pages from multiple books (start to end)", async () => {
+  //     const merger = new PDFMerger()
+  //     const tmpFile = "MergeDemo2.pdf"
+
+  //     await merger.add(
+  //       await fs.readFile(path.join(FIXTURES_DIR, "Testfile_AB.pdf")),
+  //       [1]
+  //     )
+  //     await merger.add(
+  //       await fs.readFile(path.join(FIXTURES_DIR, "UDHR.pdf")),
+  //       "1 to 3"
+  //     )
+
+  //     const buffer = await merger.saveAsBuffer()
+  //     // Write the buffer as a file for pdfDiff
+  //     await fs.writeFile(path.join(TMP_DIR, tmpFile), buffer)
+
+  //     const diff = await pdfDiff(
+  //       path.join(FIXTURES_DIR, "MergeDemo.pdf"),
+  //       path.join(TMP_DIR, tmpFile)
+  //     )
+
+  //     expect(diff).toBeFalsy()
+  //   })
+
+  test("merge pdfs from urls", async () => {
     const merger = new PDFMerger()
 
     await merger.add(
-      await fs.readFile(path.join(FIXTURES_DIR, 'Testfile_A.pdf'))
+      "https://github.com/nbesli/pdf-merger-js/raw/master/test/fixtures/Testfile_A.pdf"
     )
     await merger.add(
-      await fs.readFile(path.join(FIXTURES_DIR, 'Testfile_B.pdf'))
+      await fs.readFile(path.join(FIXTURES_DIR, "Testfile_B.pdf"))
     )
 
     const buffer = await merger.saveAsBuffer()
     // Write the buffer as a file for pdfDiff
-    await fs.writeFile(path.join(TMP_DIR, 'Testfile_AB.pdf'), buffer)
+    await fs.writeFile(path.join(TMP_DIR, "Testfile_AB.pdf"), buffer)
 
     const diff = await pdfDiff(
-      path.join(FIXTURES_DIR, 'Testfile_AB.pdf'),
-      path.join(TMP_DIR, 'Testfile_AB.pdf')
+      path.join(FIXTURES_DIR, "Testfile_AB.pdf"),
+      path.join(TMP_DIR, "Testfile_AB.pdf")
     )
 
     expect(diff).toBeFalsy()
   })
+  // })
 
-  test('combine pages from multiple books (array)', async () => {
-    const merger = new PDFMerger()
-    const tmpFile = 'MergeDemo1.pdf'
+  describe("test valid inputs", () => {
+    test("ensure Buffer can be imported", async () => {
+      expect(fileA).toBeInstanceOf(Buffer)
+      expect(fileB).toBeInstanceOf(Buffer)
 
-    await merger.add(
-      await fs.readFile(path.join(FIXTURES_DIR, 'Testfile_AB.pdf')),
-      [1]
-    )
-    await merger.add(
-      await fs.readFile(path.join(FIXTURES_DIR, 'UDHR.pdf')),
-      [1, 2, 3]
-    )
+      const merger = new PDFMerger()
+      await merger.add(fileA)
+      await merger.add(fileB)
 
-    const buffer = await merger.saveAsBuffer()
-    // Write the buffer as a file for pdfDiff
-    await fs.writeFile(path.join(TMP_DIR, tmpFile), buffer)
+      const buffer = await merger.saveAsBuffer()
+      // Write the buffer as a file for pdfDiff
+      await fs.writeFile(path.join(TMP_DIR, "Testfile_AB.pdf"), buffer)
 
-    const diff = await pdfDiff(
-      path.join(FIXTURES_DIR, 'MergeDemo.pdf'),
-      path.join(TMP_DIR, tmpFile)
-    )
+      const diff = await pdfDiff(
+        path.join(FIXTURES_DIR, "Testfile_AB.pdf"),
+        path.join(TMP_DIR, "Testfile_AB.pdf")
+      )
 
-    expect(diff).toBeFalsy()
+      expect(diff).toBeFalsy()
+    })
+
+    test("ensure ArrayBuffer can be imported", async () => {
+      function toArrayBuffer(buff) {
+        var arrayBuffer = new ArrayBuffer(buff.length)
+        var typedArray = new Uint8Array(arrayBuffer)
+        for (var i = 0; i < buff.length; ++i) {
+            typedArray[i] = buff[i]
+        }
+        return arrayBuffer
+      }
+
+      const arrayBufferA = toArrayBuffer(fileA)
+      const arrayBufferB = toArrayBuffer(fileB)
+
+      expect(arrayBufferA).toBeInstanceOf(ArrayBuffer)
+      expect(arrayBufferB).toBeInstanceOf(ArrayBuffer)
+
+      const merger = new PDFMerger()
+      await merger.add(arrayBufferA)
+      await merger.add(arrayBufferB)
+
+      const buffer = await merger.saveAsBuffer()
+      // Write the buffer as a file for pdfDiff
+      await fs.writeFile(path.join(TMP_DIR, "Testfile_AB.pdf"), buffer)
+
+      const diff = await pdfDiff(
+        path.join(FIXTURES_DIR, "Testfile_AB.pdf"),
+        path.join(TMP_DIR, "Testfile_AB.pdf")
+      )
+
+      expect(diff).toBeFalsy()
+    })
   })
 
-  test('combine pages from multiple books (start-end)', async () => {
-    const merger = new PDFMerger()
-    const tmpFile = 'MergeDemo2.pdf'
+  describe("test invalid inputs", () => {
+    test("ensure improper urls cannot be imported", async () => {
+      const merger = new PDFMerger()
 
-    await merger.add(
-      await fs.readFile(path.join(FIXTURES_DIR, 'Testfile_AB.pdf')),
-      [1]
-    )
-    await merger.add(
-      await fs.readFile(path.join(FIXTURES_DIR, 'UDHR.pdf')),
-      '1-3'
-    )
-
-    const buffer = await merger.saveAsBuffer()
-    // Write the buffer as a file for pdfDiff
-    await fs.writeFile(path.join(TMP_DIR, tmpFile), buffer)
-
-    const diff = await pdfDiff(
-      path.join(FIXTURES_DIR, 'MergeDemo.pdf'),
-      path.join(TMP_DIR, tmpFile)
-    )
-
-    expect(diff).toBeFalsy()
-  })
-
-  test('combine pages from multiple books (start - end)', async () => {
-    const merger = new PDFMerger()
-    const tmpFile = 'MergeDemo2.pdf'
-
-    await merger.add(
-      await fs.readFile(path.join(FIXTURES_DIR, 'Testfile_AB.pdf')),
-      [1]
-    )
-    await merger.add(
-      await fs.readFile(path.join(FIXTURES_DIR, 'UDHR.pdf')),
-      '1 - 3'
-    )
-
-    const buffer = await merger.saveAsBuffer()
-    // Write the buffer as a file for pdfDiff
-    await fs.writeFile(path.join(TMP_DIR, tmpFile), buffer)
-
-    const diff = await pdfDiff(
-      path.join(FIXTURES_DIR, 'MergeDemo.pdf'),
-      path.join(TMP_DIR, tmpFile)
-    )
-
-    expect(diff).toBeFalsy()
-  })
-
-  test('combine pages from multiplee books (start to end)', async () => {
-    const merger = new PDFMerger()
-    const tmpFile = 'MergeDemo2.pdf'
-
-    await merger.add(
-      await fs.readFile(path.join(FIXTURES_DIR, 'Testfile_AB.pdf')),
-      [1]
-    )
-    await merger.add(
-      await fs.readFile(path.join(FIXTURES_DIR, 'UDHR.pdf')),
-      '1 to 3'
-    )
-
-    const buffer = await merger.saveAsBuffer()
-    // Write the buffer as a file for pdfDiff
-    await fs.writeFile(path.join(TMP_DIR, tmpFile), buffer)
-
-    const diff = await pdfDiff(
-      path.join(FIXTURES_DIR, 'MergeDemo.pdf'),
-      path.join(TMP_DIR, tmpFile)
-    )
-
-    expect(diff).toBeFalsy()
-  })
-
-  test('merge pdfs from urls', async () => {
-    const merger = new PDFMerger()
-
-    await merger.add(
-      'https://github.com/nbesli/pdf-merger-js/raw/master/test/fixtures/Testfile_A.pdf'
-    )
-    await merger.add(
-      'https://github.com/nbesli/pdf-merger-js/raw/master/test/fixtures/Testfile_B.pdf'
-    )
-
-    const buffer = await merger.saveAsBuffer()
-    // Write the buffer as a file for pdfDiff
-    await fs.writeFile(path.join(TMP_DIR, 'Testfile_AB.pdf'), buffer)
-
-    const diff = await pdfDiff(
-      path.join(FIXTURES_DIR, 'Testfile_AB.pdf'),
-      path.join(TMP_DIR, 'Testfile_AB.pdf')
-    )
-
-    expect(diff).toBeFalsy()
+      await expect(merger.add("h://google.com")).rejects.toThrow(TypeError)
+      // expect(async () => await merger.add("https://google.com")).toThrow(TypeError)
+    })
   })
 
   afterAll(async () => {
     await fs.remove(TMP_DIR)
+    // await new Promise(resolve => setTimeout(resolve, 10000))
   })
 })

--- a/test/browser-fixtures.test.js
+++ b/test/browser-fixtures.test.js
@@ -2,53 +2,50 @@
  * @jest-environment jsdom
  */
 
-const path = require("path")
-const fs = require("fs-extra")
-const pdfDiff = require("pdf-diff")
-const url = require(`url`)
-const jsdom = require(`jsdom`)
-/* 
+const path = require('path')
+const fs = require('fs-extra')
+const pdfDiff = require('pdf-diff')
+/*
   add a global `windows.fetch` to mock fetch
 */
 global.window.fetch = jest.fn().mockImplementation((requestUrl) => {
-  const URL = require("url").URL;
-  console.log(requestUrl)
+  const URL = require('url').URL
   try {
     const url = new URL(requestUrl)
-    if (!["http:", "https:", "data-url:", "blob:"].includes(url.protocol)) {
+    if (!['http:', 'https:', 'data-url:', 'blob:'].includes(url.protocol)) {
       throw TypeError
     }
   } catch {
-    throw new TypeError("Failed to Fetch")
+    throw new TypeError('Failed to Fetch')
   }
-  if (requestUrl === `https://google.com`) {
-    throw new TypeError("Failed to Fetch")
+  if (requestUrl === 'https://google.com') {
+    throw new TypeError('Failed to Fetch')
   }
-  return Promise.resolve({arrayBuffer: async() => fs.readFile(path.join(FIXTURES_DIR, "Testfile_A.pdf"))})
-  })
+  return Promise.resolve({ arrayBuffer: async () => fs.readFile(path.join(FIXTURES_DIR, 'Testfile_A.pdf')) })
+})
 
-const PDFMerger = require("../browser")
+const PDFMerger = require('../browser')
 
-const FIXTURES_DIR = path.join(__dirname, "fixtures")
-const TMP_DIR = path.join(__dirname, "tmp")
+const FIXTURES_DIR = path.join(__dirname, 'fixtures')
+const TMP_DIR = path.join(__dirname, 'tmp')
 
 jest.setTimeout(100000)
 
-let fileA = undefined
-let fileB = undefined
+let fileA
+let fileB
 
 // Note: The browser tests differ from standard as all files are expected
 // to be generated or fetched before being passed into the merger.
 // For testing, they are retrieved with fs.ReadFile() and then passed in.
-describe("PDFMerger", () => {
+describe('PDFMerger', () => {
   beforeAll(async () => {
     await fs.ensureDir(TMP_DIR)
-    fileA = await fs.readFile(path.join(FIXTURES_DIR, "Testfile_A.pdf"))
-    fileB = await fs.readFile(path.join(FIXTURES_DIR, "Testfile_B.pdf"))
+    fileA = await fs.readFile(path.join(FIXTURES_DIR, 'Testfile_A.pdf'))
+    fileB = await fs.readFile(path.join(FIXTURES_DIR, 'Testfile_B.pdf'))
   })
 
-  describe("test successful merges", () => {
-    test("merge two simple files", async () => {
+  describe('test successful merges', () => {
+    test('merge two simple files', async () => {
       const merger = new PDFMerger()
 
       await merger.add(fileA)
@@ -56,26 +53,26 @@ describe("PDFMerger", () => {
 
       const buffer = await merger.saveAsBuffer()
       // Write the buffer as a file for pdfDiff
-      await fs.writeFile(path.join(TMP_DIR, "Testfile_AB.pdf"), buffer)
+      await fs.writeFile(path.join(TMP_DIR, 'Testfile_AB.pdf'), buffer)
 
       const diff = await pdfDiff(
-        path.join(FIXTURES_DIR, "Testfile_AB.pdf"),
-        path.join(TMP_DIR, "Testfile_AB.pdf")
+        path.join(FIXTURES_DIR, 'Testfile_AB.pdf'),
+        path.join(TMP_DIR, 'Testfile_AB.pdf')
       )
 
       expect(diff).toBeFalsy()
     })
 
-    test("combine pages from multiple books (array)", async () => {
+    test('combine pages from multiple books (array)', async () => {
       const merger = new PDFMerger()
-      const tmpFile = "MergeDemo1.pdf"
+      const tmpFile = 'MergeDemo1.pdf'
 
       await merger.add(
-        await fs.readFile(path.join(FIXTURES_DIR, "Testfile_AB.pdf")),
+        await fs.readFile(path.join(FIXTURES_DIR, 'Testfile_AB.pdf')),
         [1]
       )
       await merger.add(
-        await fs.readFile(path.join(FIXTURES_DIR, "UDHR.pdf")),
+        await fs.readFile(path.join(FIXTURES_DIR, 'UDHR.pdf')),
         [1, 2, 3]
       )
 
@@ -84,24 +81,24 @@ describe("PDFMerger", () => {
       await fs.writeFile(path.join(TMP_DIR, tmpFile), buffer)
 
       const diff = await pdfDiff(
-        path.join(FIXTURES_DIR, "MergeDemo.pdf"),
+        path.join(FIXTURES_DIR, 'MergeDemo.pdf'),
         path.join(TMP_DIR, tmpFile)
       )
 
       expect(diff).toBeFalsy()
     })
 
-    test("combine pages from multiple books (start-end)", async () => {
+    test('combine pages from multiple books (start-end)', async () => {
       const merger = new PDFMerger()
-      const tmpFile = "MergeDemo2.pdf"
+      const tmpFile = 'MergeDemo2.pdf'
 
       await merger.add(
-        await fs.readFile(path.join(FIXTURES_DIR, "Testfile_AB.pdf")),
+        await fs.readFile(path.join(FIXTURES_DIR, 'Testfile_AB.pdf')),
         [1]
       )
       await merger.add(
-        await fs.readFile(path.join(FIXTURES_DIR, "UDHR.pdf")),
-        "1-3"
+        await fs.readFile(path.join(FIXTURES_DIR, 'UDHR.pdf')),
+        '1-3'
       )
 
       const buffer = await merger.saveAsBuffer()
@@ -109,24 +106,24 @@ describe("PDFMerger", () => {
       await fs.writeFile(path.join(TMP_DIR, tmpFile), buffer)
 
       const diff = await pdfDiff(
-        path.join(FIXTURES_DIR, "MergeDemo.pdf"),
+        path.join(FIXTURES_DIR, 'MergeDemo.pdf'),
         path.join(TMP_DIR, tmpFile)
       )
 
       expect(diff).toBeFalsy()
     })
 
-    test("combine pages from multiple books (start - end)", async () => {
+    test('combine pages from multiple books (start - end)', async () => {
       const merger = new PDFMerger()
-      const tmpFile = "MergeDemo2.pdf"
+      const tmpFile = 'MergeDemo2.pdf'
 
       await merger.add(
-        await fs.readFile(path.join(FIXTURES_DIR, "Testfile_AB.pdf")),
+        await fs.readFile(path.join(FIXTURES_DIR, 'Testfile_AB.pdf')),
         [1]
       )
       await merger.add(
-        await fs.readFile(path.join(FIXTURES_DIR, "UDHR.pdf")),
-        "1 - 3"
+        await fs.readFile(path.join(FIXTURES_DIR, 'UDHR.pdf')),
+        '1 - 3'
       )
 
       const buffer = await merger.saveAsBuffer()
@@ -134,24 +131,24 @@ describe("PDFMerger", () => {
       await fs.writeFile(path.join(TMP_DIR, tmpFile), buffer)
 
       const diff = await pdfDiff(
-        path.join(FIXTURES_DIR, "MergeDemo.pdf"),
+        path.join(FIXTURES_DIR, 'MergeDemo.pdf'),
         path.join(TMP_DIR, tmpFile)
       )
 
       expect(diff).toBeFalsy()
     })
 
-    test("combine pages from multiple books (start to end)", async () => {
+    test('combine pages from multiple books (start to end)', async () => {
       const merger = new PDFMerger()
-      const tmpFile = "MergeDemo2.pdf"
+      const tmpFile = 'MergeDemo2.pdf'
 
       await merger.add(
-        await fs.readFile(path.join(FIXTURES_DIR, "Testfile_AB.pdf")),
+        await fs.readFile(path.join(FIXTURES_DIR, 'Testfile_AB.pdf')),
         [1]
       )
       await merger.add(
-        await fs.readFile(path.join(FIXTURES_DIR, "UDHR.pdf")),
-        "1 to 3"
+        await fs.readFile(path.join(FIXTURES_DIR, 'UDHR.pdf')),
+        '1 to 3'
       )
 
       const buffer = await merger.saveAsBuffer()
@@ -159,38 +156,38 @@ describe("PDFMerger", () => {
       await fs.writeFile(path.join(TMP_DIR, tmpFile), buffer)
 
       const diff = await pdfDiff(
-        path.join(FIXTURES_DIR, "MergeDemo.pdf"),
+        path.join(FIXTURES_DIR, 'MergeDemo.pdf'),
         path.join(TMP_DIR, tmpFile)
       )
 
       expect(diff).toBeFalsy()
     })
 
-  test("merge pdfs from urls", async () => {
-    const merger = new PDFMerger()
+    test('merge pdfs from urls', async () => {
+      const merger = new PDFMerger()
 
-    await merger.add(
-      "https://github.com/nbesli/pdf-merger-js/raw/master/test/fixtures/Testfile_A.pdf"
-    )
-    await merger.add(
-      await fs.readFile(path.join(FIXTURES_DIR, "Testfile_B.pdf"))
-    )
+      await merger.add(
+        'https://github.com/nbesli/pdf-merger-js/raw/master/test/fixtures/Testfile_A.pdf'
+      )
+      await merger.add(
+        await fs.readFile(path.join(FIXTURES_DIR, 'Testfile_B.pdf'))
+      )
 
-    const buffer = await merger.saveAsBuffer()
-    // Write the buffer as a file for pdfDiff
-    await fs.writeFile(path.join(TMP_DIR, "Testfile_AB.pdf"), buffer)
+      const buffer = await merger.saveAsBuffer()
+      // Write the buffer as a file for pdfDiff
+      await fs.writeFile(path.join(TMP_DIR, 'Testfile_AB.pdf'), buffer)
 
-    const diff = await pdfDiff(
-      path.join(FIXTURES_DIR, "Testfile_AB.pdf"),
-      path.join(TMP_DIR, "Testfile_AB.pdf")
-    )
+      const diff = await pdfDiff(
+        path.join(FIXTURES_DIR, 'Testfile_AB.pdf'),
+        path.join(TMP_DIR, 'Testfile_AB.pdf')
+      )
 
-    expect(diff).toBeFalsy()
+      expect(diff).toBeFalsy()
+    })
   })
-  })
 
-  describe("test valid inputs", () => {
-    test("ensure Buffer can be imported", async () => {
+  describe('test valid inputs', () => {
+    test('ensure Buffer can be imported', async () => {
       expect(fileA).toBeInstanceOf(Buffer)
       expect(fileB).toBeInstanceOf(Buffer)
 
@@ -200,22 +197,22 @@ describe("PDFMerger", () => {
 
       const buffer = await merger.saveAsBuffer()
       // Write the buffer as a file for pdfDiff
-      await fs.writeFile(path.join(TMP_DIR, "Testfile_AB.pdf"), buffer)
+      await fs.writeFile(path.join(TMP_DIR, 'Testfile_AB.pdf'), buffer)
 
       const diff = await pdfDiff(
-        path.join(FIXTURES_DIR, "Testfile_AB.pdf"),
-        path.join(TMP_DIR, "Testfile_AB.pdf")
+        path.join(FIXTURES_DIR, 'Testfile_AB.pdf'),
+        path.join(TMP_DIR, 'Testfile_AB.pdf')
       )
 
       expect(diff).toBeFalsy()
     })
 
-    test("ensure ArrayBuffer can be imported", async () => {
-      function toArrayBuffer(buff) {
-        var arrayBuffer = new ArrayBuffer(buff.length)
-        var typedArray = new Uint8Array(arrayBuffer)
-        for (var i = 0; i < buff.length; ++i) {
-            typedArray[i] = buff[i]
+    test('ensure ArrayBuffer can be imported', async () => {
+      function toArrayBuffer (buff) {
+        const arrayBuffer = new ArrayBuffer(buff.length)
+        const typedArray = new Uint8Array(arrayBuffer)
+        for (let i = 0; i < buff.length; ++i) {
+          typedArray[i] = buff[i]
         }
         return arrayBuffer
       }
@@ -232,30 +229,30 @@ describe("PDFMerger", () => {
 
       const buffer = await merger.saveAsBuffer()
       // Write the buffer as a file for pdfDiff
-      await fs.writeFile(path.join(TMP_DIR, "Testfile_AB.pdf"), buffer)
+      await fs.writeFile(path.join(TMP_DIR, 'Testfile_AB.pdf'), buffer)
 
       const diff = await pdfDiff(
-        path.join(FIXTURES_DIR, "Testfile_AB.pdf"),
-        path.join(TMP_DIR, "Testfile_AB.pdf")
+        path.join(FIXTURES_DIR, 'Testfile_AB.pdf'),
+        path.join(TMP_DIR, 'Testfile_AB.pdf')
       )
 
       expect(diff).toBeFalsy()
     })
 
-    test("ensure Blob can be imported", async () => {
-      class MockBlob extends Blob {
-        constructor(props) {
+    test('ensure Blob can be imported', async () => {
+      class MockBlob extends global.Blob {
+        constructor (props) {
           super(props)
 
           this.arrayBuffer = async () => {
-              return fileA
+            return fileA
           }
         }
       }
 
-      const blobA = new MockBlob([new Uint8Array(fileA, fileA.byteOffset, fileA.length)], {type: `application/pdf`})
+      const blobA = new MockBlob([new Uint8Array(fileA, fileA.byteOffset, fileA.length)], { type: 'application/pdf' })
 
-      expect(blobA).toBeInstanceOf(Blob)
+      expect(blobA).toBeInstanceOf(global.Blob)
 
       const merger = new PDFMerger()
       await merger.add(blobA)
@@ -263,23 +260,23 @@ describe("PDFMerger", () => {
 
       const buffer = await merger.saveAsBuffer()
       // Write the buffer as a file for pdfDiff
-      await fs.writeFile(path.join(TMP_DIR, "Testfile_AB.pdf"), buffer)
+      await fs.writeFile(path.join(TMP_DIR, 'Testfile_AB.pdf'), buffer)
 
       const diff = await pdfDiff(
-        path.join(FIXTURES_DIR, "Testfile_AB.pdf"),
-        path.join(TMP_DIR, "Testfile_AB.pdf")
+        path.join(FIXTURES_DIR, 'Testfile_AB.pdf'),
+        path.join(TMP_DIR, 'Testfile_AB.pdf')
       )
 
       expect(diff).toBeFalsy()
     })
   })
 
-  describe("test invalid inputs", () => {
-    test("ensure improper urls cannot be imported", async () => {
+  describe('test invalid inputs', () => {
+    test('ensure improper urls cannot be imported', async () => {
       const merger = new PDFMerger()
 
-      await expect(merger.add("h://google.com")).rejects.toThrow(TypeError)
-      await expect(merger.add("https://google.com")).rejects.toThrow(TypeError)
+      await expect(merger.add('h://google.com')).rejects.toThrow(TypeError)
+      await expect(merger.add('https://google.com')).rejects.toThrow(TypeError)
     })
   })
 

--- a/test/browser-fixtures.test.js
+++ b/test/browser-fixtures.test.js
@@ -1,6 +1,7 @@
 const path = require('path')
 const fs = require('fs-extra')
 const pdfDiff = require('pdf-diff')
+global.fetch = require('isomorphic-fetch');
 
 const PDFMerger = require('../browser')
 
@@ -134,6 +135,28 @@ describe('PDFMerger', () => {
     const diff = await pdfDiff(
       path.join(FIXTURES_DIR, 'MergeDemo.pdf'),
       path.join(TMP_DIR, tmpFile)
+    )
+
+    expect(diff).toBeFalsy()
+  })
+
+  test('merge pdfs from urls', async () => {
+    const merger = new PDFMerger()
+
+    await merger.add(
+      "https://github.com/nbesli/pdf-merger-js/raw/master/test/fixtures/Testfile_A.pdf"
+    )
+    await merger.add(
+      "https://github.com/nbesli/pdf-merger-js/raw/master/test/fixtures/Testfile_B.pdf"
+    )
+
+    const buffer = await merger.saveAsBuffer()
+    // Write the buffer as a file for pdfDiff
+    await fs.writeFile(path.join(TMP_DIR, 'Testfile_AB.pdf'), buffer)
+
+    const diff = await pdfDiff(
+      path.join(FIXTURES_DIR, 'Testfile_AB.pdf'),
+      path.join(TMP_DIR, 'Testfile_AB.pdf')
     )
 
     expect(diff).toBeFalsy()

--- a/test/browser-fixtures.test.js
+++ b/test/browser-fixtures.test.js
@@ -6,6 +6,7 @@ const path = require("path")
 const fs = require("fs-extra")
 const pdfDiff = require("pdf-diff")
 const url = require(`url`)
+const jsdom = require(`jsdom`)
 /* 
   add a global `windows.fetch` to mock fetch
 */
@@ -46,118 +47,124 @@ describe("PDFMerger", () => {
     fileB = await fs.readFile(path.join(FIXTURES_DIR, "Testfile_B.pdf"))
   })
 
-  // describe("test successful merges", () => {
-  //   test("merge two simple files", async () => {
-  //     const merger = new PDFMerger()
+  describe("test successful merges", () => {
+    test("merge two simple files", async () => {
+      const merger = new PDFMerger()
 
-  //     await merger.add(fileA)
-  //     await merger.add(fileB)
+      await merger.add(fileA)
+      await merger.add(fileB)
 
-  //     const buffer = await merger.saveAsBuffer()
-  //     // Write the buffer as a file for pdfDiff
-  //     await fs.writeFile(path.join(TMP_DIR, "Testfile_AB.pdf"), buffer)
+      const buffer = await merger.saveAsBuffer()
+      // Write the buffer as a file for pdfDiff
+      await fs.writeFile(path.join(TMP_DIR, "Testfile_AB.pdf"), buffer)
 
-  //     const diff = await pdfDiff(
-  //       path.join(FIXTURES_DIR, "Testfile_AB.pdf"),
-  //       path.join(TMP_DIR, "Testfile_AB.pdf")
-  //     )
+      const diff = await pdfDiff(
+        path.join(FIXTURES_DIR, "Testfile_AB.pdf"),
+        path.join(TMP_DIR, "Testfile_AB.pdf")
+      )
 
-  //     expect(diff).toBeFalsy()
-  //   })
+      expect(diff).toBeFalsy()
+    })
 
-  //   test("combine pages from multiple books (array)", async () => {
-  //     const merger = new PDFMerger()
-  //     const tmpFile = "MergeDemo1.pdf"
+    test("combine pages from multiple books (array)", async () => {
+      const merger = new PDFMerger()
+      const tmpFile = "MergeDemo1.pdf"
 
-  //     await merger.add(fileA, [1])
-  //     await merger.add(fileB, [1, 2, 3])
+      await merger.add(
+        await fs.readFile(path.join(FIXTURES_DIR, "Testfile_AB.pdf")),
+        [1]
+      )
+      await merger.add(
+        await fs.readFile(path.join(FIXTURES_DIR, "UDHR.pdf")),
+        [1, 2, 3]
+      )
 
-  //     const buffer = await merger.saveAsBuffer()
-  //     // Write the buffer as a file for pdfDiff
-  //     await fs.writeFile(path.join(TMP_DIR, tmpFile), buffer)
+      const buffer = await merger.saveAsBuffer()
+      // Write the buffer as a file for pdfDiff
+      await fs.writeFile(path.join(TMP_DIR, tmpFile), buffer)
 
-  //     const diff = await pdfDiff(
-  //       path.join(FIXTURES_DIR, "MergeDemo.pdf"),
-  //       path.join(TMP_DIR, tmpFile)
-  //     )
+      const diff = await pdfDiff(
+        path.join(FIXTURES_DIR, "MergeDemo.pdf"),
+        path.join(TMP_DIR, tmpFile)
+      )
 
-  //     expect(diff).toBeFalsy()
-  //   })
+      expect(diff).toBeFalsy()
+    })
 
-  //   test("combine pages from multiple books (start-end)", async () => {
-  //     const merger = new PDFMerger()
-  //     const tmpFile = "MergeDemo2.pdf"
+    test("combine pages from multiple books (start-end)", async () => {
+      const merger = new PDFMerger()
+      const tmpFile = "MergeDemo2.pdf"
 
-  //     await merger.add(
-  //       await fs.readFile(path.join(FIXTURES_DIR, "Testfile_AB.pdf")),
-  //       [1]
-  //     )
-  //     await merger.add(
-  //       await fs.readFile(path.join(FIXTURES_DIR, "UDHR.pdf")),
-  //       "1-3"
-  //     )
+      await merger.add(
+        await fs.readFile(path.join(FIXTURES_DIR, "Testfile_AB.pdf")),
+        [1]
+      )
+      await merger.add(
+        await fs.readFile(path.join(FIXTURES_DIR, "UDHR.pdf")),
+        "1-3"
+      )
 
-  //     const buffer = await merger.saveAsBuffer()
-  //     // Write the buffer as a file for pdfDiff
-  //     await fs.writeFile(path.join(TMP_DIR, tmpFile), buffer)
+      const buffer = await merger.saveAsBuffer()
+      // Write the buffer as a file for pdfDiff
+      await fs.writeFile(path.join(TMP_DIR, tmpFile), buffer)
 
-  //     const diff = await pdfDiff(
-  //       path.join(FIXTURES_DIR, "MergeDemo.pdf"),
-  //       path.join(TMP_DIR, tmpFile)
-  //     )
+      const diff = await pdfDiff(
+        path.join(FIXTURES_DIR, "MergeDemo.pdf"),
+        path.join(TMP_DIR, tmpFile)
+      )
 
-  //     expect(diff).toBeFalsy()
-  //   })
+      expect(diff).toBeFalsy()
+    })
 
-  //   test("combine pages from multiple books (start - end)", async () => {
-  //     const merger = new PDFMerger()
-  //     const tmpFile = "MergeDemo2.pdf"
+    test("combine pages from multiple books (start - end)", async () => {
+      const merger = new PDFMerger()
+      const tmpFile = "MergeDemo2.pdf"
 
-  //     await merger.add(
-  //       await fs.readFile(path.join(FIXTURES_DIR, "Testfile_AB.pdf")),
-  //       [1]
-  //     )
-  //     await merger.add(
-  //       await fs.readFile(path.join(FIXTURES_DIR, "UDHR.pdf")),
-  //       "1 - 3"
-  //     )
+      await merger.add(
+        await fs.readFile(path.join(FIXTURES_DIR, "Testfile_AB.pdf")),
+        [1]
+      )
+      await merger.add(
+        await fs.readFile(path.join(FIXTURES_DIR, "UDHR.pdf")),
+        "1 - 3"
+      )
 
-  //     const buffer = await merger.saveAsBuffer()
-  //     // Write the buffer as a file for pdfDiff
-  //     await fs.writeFile(path.join(TMP_DIR, tmpFile), buffer)
+      const buffer = await merger.saveAsBuffer()
+      // Write the buffer as a file for pdfDiff
+      await fs.writeFile(path.join(TMP_DIR, tmpFile), buffer)
 
-  //     const diff = await pdfDiff(
-  //       path.join(FIXTURES_DIR, "MergeDemo.pdf"),
-  //       path.join(TMP_DIR, tmpFile)
-  //     )
+      const diff = await pdfDiff(
+        path.join(FIXTURES_DIR, "MergeDemo.pdf"),
+        path.join(TMP_DIR, tmpFile)
+      )
 
-  //     expect(diff).toBeFalsy()
-  //   })
+      expect(diff).toBeFalsy()
+    })
 
-  //   test("combine pages from multiple books (start to end)", async () => {
-  //     const merger = new PDFMerger()
-  //     const tmpFile = "MergeDemo2.pdf"
+    test("combine pages from multiple books (start to end)", async () => {
+      const merger = new PDFMerger()
+      const tmpFile = "MergeDemo2.pdf"
 
-  //     await merger.add(
-  //       await fs.readFile(path.join(FIXTURES_DIR, "Testfile_AB.pdf")),
-  //       [1]
-  //     )
-  //     await merger.add(
-  //       await fs.readFile(path.join(FIXTURES_DIR, "UDHR.pdf")),
-  //       "1 to 3"
-  //     )
+      await merger.add(
+        await fs.readFile(path.join(FIXTURES_DIR, "Testfile_AB.pdf")),
+        [1]
+      )
+      await merger.add(
+        await fs.readFile(path.join(FIXTURES_DIR, "UDHR.pdf")),
+        "1 to 3"
+      )
 
-  //     const buffer = await merger.saveAsBuffer()
-  //     // Write the buffer as a file for pdfDiff
-  //     await fs.writeFile(path.join(TMP_DIR, tmpFile), buffer)
+      const buffer = await merger.saveAsBuffer()
+      // Write the buffer as a file for pdfDiff
+      await fs.writeFile(path.join(TMP_DIR, tmpFile), buffer)
 
-  //     const diff = await pdfDiff(
-  //       path.join(FIXTURES_DIR, "MergeDemo.pdf"),
-  //       path.join(TMP_DIR, tmpFile)
-  //     )
+      const diff = await pdfDiff(
+        path.join(FIXTURES_DIR, "MergeDemo.pdf"),
+        path.join(TMP_DIR, tmpFile)
+      )
 
-  //     expect(diff).toBeFalsy()
-  //   })
+      expect(diff).toBeFalsy()
+    })
 
   test("merge pdfs from urls", async () => {
     const merger = new PDFMerger()
@@ -180,7 +187,7 @@ describe("PDFMerger", () => {
 
     expect(diff).toBeFalsy()
   })
-  // })
+  })
 
   describe("test valid inputs", () => {
     test("ensure Buffer can be imported", async () => {
@@ -234,6 +241,37 @@ describe("PDFMerger", () => {
 
       expect(diff).toBeFalsy()
     })
+
+    test("ensure Blob can be imported", async () => {
+      class MockBlob extends Blob {
+        constructor(props) {
+          super(props)
+
+          this.arrayBuffer = async () => {
+              return fileA
+          }
+        }
+      }
+
+      const blobA = new MockBlob([new Uint8Array(fileA, fileA.byteOffset, fileA.length)], {type: `application/pdf`})
+
+      expect(blobA).toBeInstanceOf(Blob)
+
+      const merger = new PDFMerger()
+      await merger.add(blobA)
+      await merger.add(fileB)
+
+      const buffer = await merger.saveAsBuffer()
+      // Write the buffer as a file for pdfDiff
+      await fs.writeFile(path.join(TMP_DIR, "Testfile_AB.pdf"), buffer)
+
+      const diff = await pdfDiff(
+        path.join(FIXTURES_DIR, "Testfile_AB.pdf"),
+        path.join(TMP_DIR, "Testfile_AB.pdf")
+      )
+
+      expect(diff).toBeFalsy()
+    })
   })
 
   describe("test invalid inputs", () => {
@@ -241,7 +279,7 @@ describe("PDFMerger", () => {
       const merger = new PDFMerger()
 
       await expect(merger.add("h://google.com")).rejects.toThrow(TypeError)
-      // expect(async () => await merger.add("https://google.com")).toThrow(TypeError)
+      await expect(merger.add("https://google.com")).rejects.toThrow(TypeError)
     })
   })
 


### PR DESCRIPTION
### Summary

Changes to pdf-merger-js/browser:
- Adds the ability to pass a url into the merger to be fetched
- Supports any valid url schema for fetch from an external or internal resource (`http`, `https`, `about`, `blob`, `data`, or `file`). See: [fetch documentation](https://fetch.spec.whatwg.org/#url)
- Cleans up the code path in _getInputFile a bit to ensure proper execution based on the type of `inputFile`

Changes to browser-fixtures-test:
- Adds test for fetching Testfile_A.pdf and Testfile_B.pdf directly from github
- Adds isomorphic-fetch to devDependencies in order to override fetch for jest testing

### Closing Comments

This should allow pdf-merger-js/browser to be more convenient to use. #51 created the browser version to be feature comparable to the non-browser version, but this adds an additional helpful feature that is simple to implement and use due to the native fetch api.

See: #17 