### PR TITLE
Add type declaration for pdf-merger-js/browser

### DIFF
--- a/browser.d.ts
+++ b/browser.d.ts
@@ -1,0 +1,15 @@
+// Type definitions for pdf-merger-js v3.0.1
+// Project: https://github.com/nbesli/pdf-merger-js
+// Definitions by: Alexander Wunschik <https://github.com/mojoaxel/>
+//                 Daniel Hammer <https://github.com/danmhammer/>
+class PDFMerger {
+  constructor();
+  add(inputFile: string | ArrayBuffer | Blob | Buffer | File, pages?: string | string[] | undefined | null): Promise<undefined>;
+  save(fileName: string): Promise<undefined>;
+  saveAsBuffer(): Promise<Buffer>;
+  saveAsBlob(): Promise<Blob>;
+}
+
+declare module "pdf-merger-js/browser" {
+  export = PDFMerger;
+}


### PR DESCRIPTION
### Summary

Adds `browser.d.ts` to declare types for the browser version. 