### PR TITLE
Bugfix: Improve Performance by not reloading inputFile multiple times

### DIFF
--- a/index.js
+++ b/index.js
@@ -39,10 +39,11 @@ class PDFMerger {
 
   _addFromToPage (inputFile, from, to) {
     if (typeof from === 'number' && typeof to === 'number' && from > 0 && to > from) {
+      const src = (inputFile instanceof Buffer) ? inputFile : fs.readFileSync(inputFile)
+      const ext = new pdf.ExternalDocument(src)
+      this.doc.setTemplate(ext)
+
       for (let i = from; i <= to; i++) {
-        const src = (inputFile instanceof Buffer) ? inputFile : fs.readFileSync(inputFile)
-        const ext = new pdf.ExternalDocument(src)
-        this.doc.setTemplate(ext)
         this.doc.addPageOf(i, ext)
       }
     } else {
@@ -52,10 +53,11 @@ class PDFMerger {
 
   _addGivenPages (inputFile, pages) {
     if (pages.length > 0) {
+      const src = (inputFile instanceof Buffer) ? inputFile : fs.readFileSync(inputFile)
+      const ext = new pdf.ExternalDocument(src)
+      this.doc.setTemplate(ext)
+
       for (const page in pages) {
-        const src = (inputFile instanceof Buffer) ? inputFile : fs.readFileSync(inputFile)
-        const ext = new pdf.ExternalDocument(src)
-        this.doc.setTemplate(ext)
         this.doc.addPageOf(pages[page], ext)
       }
     }

--- a/package.json
+++ b/package.json
@@ -7,8 +7,9 @@
   "scripts": {
     "standard": "standard",
     "standard:fix": "standard --fix",
-    "test": "jest --detectOpenHandles",
-    "test:watch": "jest --watch --forceExit --detectOpenHandles"
+    "test": "jest --testPathIgnorePatterns 'performance.test.js' --detectOpenHandles",
+    "test:watch": "jest --testPathIgnorePatterns 'performance.test.js' --watch --forceExit --detectOpenHandles",
+    "test:performance": "node --expose-gc ./node_modules/.bin/jest --runInBand --detectOpenHandles performance.test.js"
   },
   "standard": {
     "env": [

--- a/package.json
+++ b/package.json
@@ -7,9 +7,8 @@
   "scripts": {
     "standard": "standard",
     "standard:fix": "standard --fix",
-    "test": "jest --testPathIgnorePatterns 'performance.test.js' --detectOpenHandles",
-    "test:watch": "jest --testPathIgnorePatterns 'performance.test.js' --watch --forceExit --detectOpenHandles",
-    "test:performance": "node --expose-gc ./node_modules/.bin/jest --runInBand --detectOpenHandles performance.test.js"
+    "test": "jest --detectOpenHandles",
+    "test:watch": "jest --watch --forceExit --detectOpenHandles"
   },
   "standard": {
     "env": [


### PR DESCRIPTION
### Summary

Closes: #27 

Changes: 
- Moves inputFile loading, ExternalDocument creation, and template setting out of for loop in _addFromToPage and _addGivenPages in order to dramatically reduce memory usage and execution time. These tasks only need to be performed once and are quite memory intensive.

### Testing

I performed some testing on this branch: https://github.com/DanMHammer/pdf-merger-js/tree/bugfix/performance-improvement-with-old

To replicate the testing, clone the branch and run:
`npm run test:performance`

I did not include this performance test in this PR as it requires some larger PDF files and keeping around the old version of index.js

### Sample Test Results

```
[
      {
        name: 'performance issues memory and time issues original: Merging several PDFs takes a long time/Uses a lot of memory (#27)',
        time: '31.124112105 s',
        memory: '1380.92578125 MB'
      },
      {
        name: 'performance issues memory and time issues fixed: Merging several PDFs takes a long time/Uses a lot of memory (#27)',
        time: '3.884552957 s',
        memory: '200.70703125 MB'
      },
      {
        name: 'performance issues memory and time issues browser: Merging several PDFs takes a long time/Uses a lot of memory (#27)',
        time: '1.764709906 s',
        memory: '175.82421875 MB'
      }
    ]
```