### PR TITLE
Remove race condition from React example, refs #62

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,9 @@ const Merger = (files) => {
     const render = async () => {
       const merger = new PDFMerger();
 
-      await Promise.all(files.map(async (file) => await merger.add(file)));
+      for(const file of files) {
+        await merger.add(file)
+      }
 
       const mergedPdf = await merger.saveAsBlob();
       const url = URL.createObjectURL(mergedPdf);


### PR DESCRIPTION
See my comment on https://github.com/nbesli/pdf-merger-js/issues/62

By using `Promise.all` this way you are basically adding all files in a random order, with a larger probability for smaller files appearing before larger files.