### PR TITLE
Include passthrough of `pdfjs` options

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -1,8 +1,8 @@
 const pdf = require('pdfjs')
 
 class PDFMerger {
-  constructor () {
-    this._resetDoc()
+  constructor (pdfjsOptions = {}) {
+    this._resetDoc(pdfjsOptions)
   }
 
   async add (inputFile, pages) {
@@ -31,11 +31,11 @@ class PDFMerger {
     }
   }
 
-  _resetDoc () {
+  _resetDoc (pdfjsOptions = {}) {
     if (this.doc) {
       delete this.doc
     }
-    this.doc = new pdf.Document()
+    this.doc = new pdf.Document(pdfjsOptions)
   }
 
   async _getInputFile (inputFile) {

--- a/index.js
+++ b/index.js
@@ -2,8 +2,8 @@ const pdf = require('pdfjs')
 const fs = require('fs')
 
 class PDFMerger {
-  constructor () {
-    this._resetDoc()
+  constructor (pdfjsOptions = {}) {
+    this._resetDoc(pdfjsOptions)
   }
 
   add (inputFile, pages) {
@@ -24,11 +24,11 @@ class PDFMerger {
     }
   }
 
-  _resetDoc () {
+  _resetDoc (pdfjsOptions = {}) {
     if (this.doc) {
       delete this.doc
     }
-    this.doc = new pdf.Document()
+    this.doc = new pdf.Document(pdfjsOptions)
   }
 
   _addEntireDocument (inputFile) {


### PR DESCRIPTION
This PR introduces an optional argument `pdfjsOptions` for the initialisation of the `PDFMerger` class, as well as in `PDFMerger._resetDoc`.

Details of such options can be found in [`pdfjs` documentation](https://github.com/rkusa/pdfjs/tree/main/docs#new-pdfdocumentopts).