### PR TITLE
Added functionality to add metadata to PDFDocument

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ The node.js version has the following export functions:
 
 * `saveAsBuffer` exports a merged pdf as an [Buffer](https://nodejs.org/api/buffer.html).
 * `save` saves the pdf under the given filename.
+* `setMetadata` set Metadata for producer, author, title or creator
 
 ### async node.js example
 
@@ -50,6 +51,7 @@ The Browser version has the following export functions:
 * `saveAsBuffer` exports a merged pdf as an [Uint8Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Uint8Array).
 * `saveAsBlob` exports a merged pdf as a [Blob](https://developer.mozilla.org/en-US/docs/Web/API/Blob).
 * `save` starts a file-download directly in the browser.
+* `setMetadata` set Metadata for producer, author, title or creator
 
 #### Sample - React
 
@@ -93,6 +95,27 @@ const Merger = (files) => {
     ></iframe>
   );
 };
+```
+
+#### Sample - Set Metadata
+
+```js
+const merger = new PDFMerger();
+
+// Add files
+
+// Set only producer
+await merger.setMetadata({
+  producer: "Custom Producer",
+});
+
+// Set all 4 fields
+await merger.setMetadata({
+  producer: "Custom Producer",
+  author: "Custom Author",
+  creator: "Custom Creator",
+  title: "Custom Title"
+});
 ```
 
 ## Similar libraries

--- a/browser.d.ts
+++ b/browser.d.ts
@@ -16,7 +16,7 @@ declare module "pdf-merger-js/browser" {
   export = PDFMerger;
 }
 
-declare class Metadata {
+declare interface Metadata {
   producer?: string
   author?: string
   title?: string

--- a/browser.d.ts
+++ b/browser.d.ts
@@ -10,7 +10,15 @@ declare module "pdf-merger-js/browser" {
     save(fileName: string): Promise<undefined>;
     saveAsBuffer(): Promise<Uint8Array>;
     saveAsBlob(): Promise<Blob>;
+    setMetadata(metadata: Metadata): Promise<void>;
   }
 
   export = PDFMerger;
+}
+
+declare class Metadata {
+  producer?: string
+  author?: string
+  title?: string
+  creator?: string
 }

--- a/browser.js
+++ b/browser.js
@@ -119,6 +119,14 @@ class PDFMerger {
     })
   }
 
+  async setMetadata(metadata) {
+    await this._ensureDoc()
+    if (metadata.producer) this.doc.setProducer(metadata.producer)
+    if (metadata.author) this.doc.setAuthor(metadata.author)
+    if (metadata.title) this.doc.setTitle(metadata.title)
+    if (metadata.creator) this.doc.setCreator(metadata.creator)
+  }
+
   async saveAsBuffer () {
     await this._ensureDoc()
     return await this.doc.save()

--- a/browser.js
+++ b/browser.js
@@ -119,7 +119,7 @@ class PDFMerger {
     })
   }
 
-  async setMetadata(metadata) {
+  async setMetadata (metadata) {
     await this._ensureDoc()
     if (metadata.producer) this.doc.setProducer(metadata.producer)
     if (metadata.author) this.doc.setAuthor(metadata.author)

--- a/index.d.ts
+++ b/index.d.ts
@@ -14,7 +14,7 @@ declare module "pdf-merger-js" {
 }
 
 
-declare class Metadata {
+declare interface Metadata {
   producer?: string
   author?: string
   title?: string

--- a/index.d.ts
+++ b/index.d.ts
@@ -8,7 +8,15 @@ declare module "pdf-merger-js" {
     add(inputFile: string | Buffer | ArrayBuffer, pages?: string | string[] | undefined | null): Promise<undefined>;
     save(fileName: string): Promise<undefined>;
     saveAsBuffer(): Promise<Buffer>;
+    setMetadata(metadata: Metadata): Promise<void>;
   }
-
   export = PDFMerger;
+}
+
+
+declare class Metadata {
+  producer?: string
+  author?: string
+  title?: string
+  creator?: string
 }

--- a/index.js
+++ b/index.js
@@ -98,7 +98,7 @@ class PDFMerger {
     })
   }
 
-  async setMetadata(metadata) {
+  async setMetadata (metadata) {
     await this._ensureDoc()
     if (metadata.producer) this.doc.setProducer(metadata.producer)
     if (metadata.author) this.doc.setAuthor(metadata.author)

--- a/index.js
+++ b/index.js
@@ -98,6 +98,14 @@ class PDFMerger {
     })
   }
 
+  async setMetadata(metadata) {
+    await this._ensureDoc()
+    if (metadata.producer) this.doc.setProducer(metadata.producer)
+    if (metadata.author) this.doc.setAuthor(metadata.author)
+    if (metadata.title) this.doc.setTitle(metadata.title)
+    if (metadata.creator) this.doc.setCreator(metadata.creator)
+  }
+
   async save (fileName) {
     await this._ensureDoc()
     const pdfBytes = await this.doc.save()

--- a/test/fixtures.test.js
+++ b/test/fixtures.test.js
@@ -1,6 +1,7 @@
 const path = require('path')
 const fs = require('fs-extra')
 const pdfDiff = require('pdf-diff')
+const { PDFDocument } = require('pdf-lib')
 
 const PDFMerger = require('../index')
 
@@ -123,6 +124,25 @@ describe('PDFMerger', () => {
     await merger.add(path.join(FIXTURES_DIR, 'Testfile_AB.pdf'))
     const buffer = await merger.saveAsBuffer()
     expect(buffer instanceof Buffer).toEqual(true)
+  })
+
+  test('set title and check if title is set properly', async () => {
+    const merger = new PDFMerger()
+    await merger.add(path.join(FIXTURES_DIR, 'Testfile_A.pdf'))
+
+    const testTitle = "Test Title"
+
+    merger.setMetadata({
+      title: testTitle
+    })
+
+    await merger.save(path.join(TMP_DIR, 'Testfile_A_Metadata.pdf'))
+    const pdfData = fs.readFileSync(path.join(TMP_DIR, 'Testfile_A_Metadata.pdf'));
+
+    const outputDocument = await PDFDocument.load(pdfData, {ignoreEncryption: true})
+    const outputTitle = outputDocument.getTitle()
+
+    expect(testTitle).toBe(outputTitle)
   })
 
   afterAll(async () => {

--- a/test/fixtures.test.js
+++ b/test/fixtures.test.js
@@ -132,7 +132,7 @@ describe('PDFMerger', () => {
 
     const testTitle = "Test Title"
 
-    merger.setMetadata({
+    await merger.setMetadata({
       title: testTitle
     })
 

--- a/test/fixtures.test.js
+++ b/test/fixtures.test.js
@@ -130,16 +130,16 @@ describe('PDFMerger', () => {
     const merger = new PDFMerger()
     await merger.add(path.join(FIXTURES_DIR, 'Testfile_A.pdf'))
 
-    const testTitle = "Test Title"
+    const testTitle = 'Test Title'
 
     await merger.setMetadata({
       title: testTitle
     })
 
     await merger.save(path.join(TMP_DIR, 'Testfile_A_Metadata.pdf'))
-    const pdfData = fs.readFileSync(path.join(TMP_DIR, 'Testfile_A_Metadata.pdf'));
+    const pdfData = fs.readFileSync(path.join(TMP_DIR, 'Testfile_A_Metadata.pdf'))
 
-    const outputDocument = await PDFDocument.load(pdfData, {ignoreEncryption: true})
+    const outputDocument = await PDFDocument.load(pdfData, { ignoreEncryption: true })
     const outputTitle = outputDocument.getTitle()
 
     expect(testTitle).toBe(outputTitle)


### PR DESCRIPTION
While using this library I noticed that there is no possibility to add/change the metadata of the PDF-Document like title, author or producer. This pull request will add this feature to the library. I am not entirely sure about the conventions of the type declarations, so it would be great if anyone had a look and provide feedback. 

- Added function setMetadata which expects object of type Metadata
- Function setMetadata sets metadata for producer, author, title, creator
- The function ensures the document is present by internal _ensureDoc function
- Due to the _ensureDoc check the funtion is async
- Added type declarations for Metadata by adding an interface