### PR TITLE
Reset the doc after save

### DIFF
--- a/index.js
+++ b/index.js
@@ -110,6 +110,7 @@ class PDFMerger {
     await this._ensureDoc()
     const pdfBytes = await this.doc.save()
     await fs.writeFile(fileName, pdfBytes)
+    this.doc = undefined
   }
 
   async saveAsBuffer () {


### PR DESCRIPTION
The new pdfs were getting merged with the previously merged pdf file. So reset the doc to avoid merging of previous docs with the current doc.