### PR TITLE
feat: add reset function

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Description
 
-This node.js library can **merge multiple PDF documents**, or parts of them, to one new PDF document. It's only dependency is [pdf-lib](https://pdf-lib.js.org/) so it can run in any javascript-only environnement **without any external dependencies**.
+This node.js library can **merge multiple PDF documents**, or parts of them, to one new PDF document. It's only dependency is [pdf-lib](https://pdf-lib.js.org/) so it can run in any javascript-only environment **without any external dependencies**.
 
 > If you are searching for the legacy version based on 
 [pdfjs](https://www.npmjs.com/package/pdfjs) please install a [v3 release](https://github.com/nbesli/pdf-merger-js/releases?q=v3&expanded=true). Since [v4](https://github.com/nbesli/pdf-merger-js/releases?q=v4&expanded=true) we use [pdf-lib](https://pdf-lib.js.org/) instead.
@@ -19,7 +19,8 @@ The node.js version has the following export functions:
 
 * `saveAsBuffer` exports a merged pdf as an [Buffer](https://nodejs.org/api/buffer.html).
 * `save` saves the pdf under the given filename.
-* `setMetadata` set Metadata for producer, author, title or creator
+* `setMetadata` set Metadata for producer, author, title or creator.
+* `reset` resets the internal state of the document, to start again.
 
 ### async node.js example
 
@@ -51,7 +52,8 @@ The Browser version has the following export functions:
 * `saveAsBuffer` exports a merged pdf as an [Uint8Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Uint8Array).
 * `saveAsBlob` exports a merged pdf as a [Blob](https://developer.mozilla.org/en-US/docs/Web/API/Blob).
 * `save` starts a file-download directly in the browser.
-* `setMetadata` set Metadata for producer, author, title or creator
+* `setMetadata` set Metadata for producer, author, title or creator.
+* `reset` resets the internal state of the document, to start again.
 
 #### Sample - React
 

--- a/browser.js
+++ b/browser.js
@@ -2,6 +2,10 @@ const { PDFDocument } = require('pdf-lib')
 
 class PDFMerger {
   constructor () {
+    this.reset()
+  }
+
+  reset () {
     this.doc = undefined
   }
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,10 +1,11 @@
-// Type definitions for pdf-merger-js v3.4.0
+// Type definitions for pdf-merger-js v4.2.1+
 // Project: https://github.com/nbesli/pdf-merger-js
 // Definitions by: Alexander Wunschik <https://github.com/mojoaxel/>
 
 declare module "pdf-merger-js" {
   class PDFMerger {
     constructor();
+    reset(): void;
     add(inputFile: string | Buffer | ArrayBuffer, pages?: string | string[] | undefined | null): Promise<undefined>;
     save(fileName: string): Promise<undefined>;
     saveAsBuffer(): Promise<Buffer>;

--- a/index.js
+++ b/index.js
@@ -3,12 +3,16 @@ const fs = require('fs').promises
 
 class PDFMerger {
   constructor () {
-    this.doc = undefined
+    this.reset()
 
     this.loadOptions = {
       // allow merging of encrypted pdfs (issue #88)
       ignoreEncryption: true
     }
+  }
+
+  reset () {
+    this.doc = undefined
   }
 
   async add (inputFile, pages) {

--- a/test/browser-fixtures.test.js
+++ b/test/browser-fixtures.test.js
@@ -194,6 +194,27 @@ describe('PDFMerger', () => {
 
       expect(diff).toBeFalsy()
     })
+
+    test('merge two simple files', async () => {
+      const merger = new PDFMerger()
+
+      await merger.add(fileB)
+      merger.reset()
+
+      await merger.add(fileA)
+      await merger.add(fileB)
+
+      const buffer = await merger.saveAsBuffer()
+      // Write the buffer as a file for pdfDiff
+      await fs.writeFile(path.join(TMP_DIR, 'Testfile_AB.pdf'), buffer)
+
+      const diff = await pdfDiff(
+        path.join(FIXTURES_DIR, 'Testfile_AB.pdf'),
+        path.join(TMP_DIR, 'Testfile_AB.pdf')
+      )
+
+      expect(diff).toBeFalsy()
+    })
   })
 
   describe('test valid inputs', () => {

--- a/test/fixtures.test.js
+++ b/test/fixtures.test.js
@@ -29,7 +29,23 @@ describe('PDFMerger', () => {
     expect(diff).toBeFalsy()
   })
 
-  test('combine pages from multibe books (array)', async () => {
+  test('reset the internal document', async () => {
+    const merger = new PDFMerger()
+    await merger.add(path.join(FIXTURES_DIR, 'MergeDemo.pdf'))
+    merger.reset()
+    await merger.add(path.join(FIXTURES_DIR, 'Testfile_A.pdf'))
+    await merger.add(path.join(FIXTURES_DIR, 'Testfile_B.pdf'))
+    await merger.save(path.join(TMP_DIR, 'Testfile_AB.pdf'))
+
+    const diff = await pdfDiff(
+      path.join(FIXTURES_DIR, 'Testfile_AB.pdf'),
+      path.join(TMP_DIR, 'Testfile_AB.pdf')
+    )
+
+    expect(diff).toBeFalsy()
+  })
+
+  test('combine pages from multipel books (array)', async () => {
     const merger = new PDFMerger()
     const tmpFile = 'MergeDemo1.pdf'
     await merger.add(path.join(FIXTURES_DIR, 'Testfile_AB.pdf'), [1])
@@ -44,7 +60,7 @@ describe('PDFMerger', () => {
     expect(diff).toBeFalsy()
   })
 
-  test('combine pages from multibe books (string - array)', async () => {
+  test('combine pages from multipel books (string - array)', async () => {
     const merger = new PDFMerger()
     const tmpFile = 'MergeDemo1.pdf'
     await merger.add(path.join(FIXTURES_DIR, 'Testfile_AB.pdf'), '1')
@@ -59,7 +75,7 @@ describe('PDFMerger', () => {
     expect(diff).toBeFalsy()
   })
 
-  test('combine pages from multibe books (plain number - array)', async () => {
+  test('combine pages from multipel books (plain number - array)', async () => {
     const merger = new PDFMerger()
     const tmpFile = 'MergeDemo1.pdf'
     await merger.add(path.join(FIXTURES_DIR, 'Testfile_AB.pdf'), 1)
@@ -74,22 +90,7 @@ describe('PDFMerger', () => {
     expect(diff).toBeFalsy()
   })
 
-  test('combine pages from multibe books (start-end)', async () => {
-    const merger = new PDFMerger()
-    const tmpFile = 'MergeDemo2.pdf'
-    await merger.add(path.join(FIXTURES_DIR, 'Testfile_AB.pdf'), [1])
-    await merger.add(path.join(FIXTURES_DIR, 'UDHR.pdf'), '1-3')
-    await merger.save(path.join(TMP_DIR, tmpFile))
-
-    const diff = await pdfDiff(
-      path.join(FIXTURES_DIR, 'MergeDemo.pdf'),
-      path.join(TMP_DIR, tmpFile)
-    )
-
-    expect(diff).toBeFalsy()
-  })
-
-  test('combine pages from multibe books (start - end)', async () => {
+  test('combine pages from multipel books (start - end)', async () => {
     const merger = new PDFMerger()
     const tmpFile = 'MergeDemo2.pdf'
     await merger.add(path.join(FIXTURES_DIR, 'Testfile_AB.pdf'), [1])
@@ -104,11 +105,26 @@ describe('PDFMerger', () => {
     expect(diff).toBeFalsy()
   })
 
-  test('combine pages from multibe books (start to end)', async () => {
+  test('combine pages from multipel books (start to end)', async () => {
     const merger = new PDFMerger()
     const tmpFile = 'MergeDemo2.pdf'
     await merger.add(path.join(FIXTURES_DIR, 'Testfile_AB.pdf'), [1])
     await merger.add(path.join(FIXTURES_DIR, 'UDHR.pdf'), '1 to 3')
+    await merger.save(path.join(TMP_DIR, tmpFile))
+
+    const diff = await pdfDiff(
+      path.join(FIXTURES_DIR, 'MergeDemo.pdf'),
+      path.join(TMP_DIR, tmpFile)
+    )
+
+    expect(diff).toBeFalsy()
+  })
+
+  test('combine pages from multipel books (start-end)', async () => {
+    const merger = new PDFMerger()
+    const tmpFile = 'MergeDemo2.pdf'
+    await merger.add(path.join(FIXTURES_DIR, 'Testfile_AB.pdf'), [1])
+    await merger.add(path.join(FIXTURES_DIR, 'UDHR.pdf'), '1-3')
     await merger.save(path.join(TMP_DIR, tmpFile))
 
     const diff = await pdfDiff(

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,0 +1,15 @@
+export = PDFMerger;
+declare class PDFMerger {
+    /**
+     * Resets the internal PDFDocument.
+     * Call this method if you want to start merging a new document.
+     *
+     * @returns {void}
+     */
+    reset(): void;
+    add(inputFile: any, pages: any): Promise<void>;
+    setMetadata(metadata: any): Promise<void>;
+    save(fileName: any): Promise<void>;
+    saveAsBuffer(): Promise<Buffer>;
+    #private;
+}


### PR DESCRIPTION
Add a `reset` function to reset the internal document.

See discussion: https://github.com/nbesli/pdf-merger-js/pull/108#issuecomment-1446991332 

*this replaces #108*