### PR TITLE
Update line no 30 in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ The node.js version has the following export functions:
 ```js
 const PDFMerger = require('pdf-merger-js');
 
-var merger = new PDFMerger();
+let merger = new PDFMerger();
 
 (async () => {
   await merger.add('pdf1.pdf');  //merge all pages. parameter is the path to file and filename.


### PR DESCRIPTION
Update line no 30 from "var manager" to "let manager" It will run both Windows and Linux, previously showing error on Windows 

Windows version: 11
<img width="682" alt="image" src="https://github.com/nbesli/pdf-merger-js/assets/13980656/7ecea07c-37a7-4c69-bd40-b06c56f75b97">
