### PR TITLE
type definition file index.d.ts export modified to match default expo…

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -46,7 +46,7 @@ declare module "pdf-merger-js" {
      */
     setMetadata(metadata: Metadata): Promise<void>;
   }
-  export = PDFMerger;
+  export default PDFMerger;
 }
 
 declare type PdfInput = Uint8Array | ArrayBuffer | Blob | URL | Buffer | String | PathLike | string;


### PR DESCRIPTION
type definition file index.d.ts export modified to match default export used in index.js


Also, these changes fix the following issue.
https://github.com/nbesli/pdf-merger-js/issues/136