### PR TITLE
match browser.js default export

### DIFF
--- a/browser.d.ts
+++ b/browser.d.ts
@@ -55,7 +55,7 @@ declare module "pdf-merger-js/browser" {
     setMetadata(metadata: Metadata): Promise<void>;
   }
 
-  export = PDFMerger;
+  export default PDFMerger;
 }
 
 declare type PdfInput = Uint8Array | ArrayBuffer | Blob | URL | File | String | string;


### PR DESCRIPTION
Similar change to #137 - Found this during an Angular v19 upgrade.