### PR TITLE
Switch to @cantoo/pdf-lib and add loadOptions support for encrypted PDFs

### DIFF
--- a/PDFMergerBase.js
+++ b/PDFMergerBase.js
@@ -31,7 +31,8 @@ export default class PDFMergerBase {
    */
   _loadOptions = {
     // allow merging of encrypted pdfs (issue #88)
-    ignoreEncryption: true
+    ignoreEncryption: true,
+    password: ''
   }
 
   constructor () {

--- a/PDFMergerBase.js
+++ b/PDFMergerBase.js
@@ -26,16 +26,26 @@ export default class PDFMergerBase {
   /**
    * The load options for pdf-lib.
    *
-   * @type { import('pdf-lib').LoadOptions }
+   * @type { import('@cantoo/pdf-lib').LoadOptions }
    * @protected
    */
   _loadOptions = {
-    // allow merging of encrypted pdfs (issue #88)
+    // in order to bypass passwordless encryption we set the password to ''
     ignoreEncryption: true,
     password: ''
   }
 
-  constructor () {
+  /**
+   * Default constructor
+   *
+   * @param { import('@cantoo/pdf-lib').LoadOptions } loadOptions
+   */
+  constructor (loadOptions = {}) {
+    this._loadOptions = {
+      ...this._loadOptions,
+      ...loadOptions
+    }
+
     this.reset()
   }
 

--- a/PDFMergerBase.js
+++ b/PDFMergerBase.js
@@ -1,4 +1,4 @@
-import { PDFDocument } from 'pdf-lib'
+import { PDFDocument } from '@cantoo/pdf-lib'
 
 import { parsePagesString } from './parsePagesString.js'
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 This fork is replacing pdf-lib with @cantoo/pdf-lib, a better maintained library.
 After pdf-merger-js will also update the library with a better one, this project will be removed.
 
-Install with: npm install @radui1398/pdf-merger-js
+Install with: npm install @radui1398/pdf-merger
 
 # Description
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+# Forked by radui1398
+This fork is replacing pdf-lib with @cantoo/pdf-lib, a better maintained library.
+After pdf-merger-js will also update the library with a better one, this project will be removed.
+
+Install with: npm install @radui1398/pdf-merger-js
+
 # Description
 
 This node.js library can **merge multiple PDF documents**, or parts of them, to one new PDF document. You can do this by using the **command line interface** or from within your **node.js** or even directly in the **browser**.

--- a/browser.d.ts
+++ b/browser.d.ts
@@ -6,7 +6,13 @@
 
 declare module "@radui1398/pdf-merger-js/browser" {
   class PDFMerger {
-    constructor();
+    /**
+     * Class constructor
+     *
+     * @param { import('@cantoo/pdf-lib').LoadOptions } loadOptions
+     */
+    constructor(loadOptions: import('@cantoo/pdf-lib').LoadOptions);
+
     /**
      * Resets the internal state of the document, to start again.
      *

--- a/browser.d.ts
+++ b/browser.d.ts
@@ -4,7 +4,7 @@
 //                 Daniel Hammer <https://github.com/danmhammer/>
 //                 Lukas Loeffler <https://github.com/LukasLoeffler>
 
-declare module "pdf-merger-js/browser" {
+declare module "@radui1398/pdf-merger-js/browser" {
   class PDFMerger {
     constructor();
     /**

--- a/index.d.ts
+++ b/index.d.ts
@@ -4,7 +4,7 @@
 
 import { PathLike } from "fs-extra";
 
-declare module "pdf-merger-js" {
+declare module "@radui1398/pdf-merger-js" {
   class PDFMerger {
     constructor();
     /**

--- a/index.d.ts
+++ b/index.d.ts
@@ -6,7 +6,13 @@ import { PathLike } from "fs-extra";
 
 declare module "@radui1398/pdf-merger-js" {
   class PDFMerger {
-    constructor();
+    /**
+     * Class constructor
+     *
+     * @param { import('@cantoo/pdf-lib').LoadOptions } loadOptions
+     */
+    constructor(loadOptions: import('@cantoo/pdf-lib').LoadOptions);
+
     /**
      * Resets the internal state of the document, to start again.
      *

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,8 @@
       "version": "5.1.2",
       "license": "MIT",
       "dependencies": {
-        "commander": "^11.1.0",
-        "pdf-lib": "^1.17.1"
+        "@cantoo/pdf-lib": "^2.4.2",
+        "commander": "^11.1.0"
       },
       "bin": {
         "pdf-merge": "cli.js"
@@ -24,7 +24,7 @@
         "standard": "^17.1.0"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=16"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -671,6 +671,27 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true
     },
+    "node_modules/@cantoo/pdf-lib": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@cantoo/pdf-lib/-/pdf-lib-2.4.2.tgz",
+      "integrity": "sha512-ZqMiY8XEyM6Rc3WjpsQnrZYwCdyf/Emg2J3RbmSxoIKN1Kpa/93uIaO9cx/14dJoC6vkcAtMhrYsO7YLB8i8Lg==",
+      "license": "MIT",
+      "dependencies": {
+        "@pdf-lib/standard-fonts": "^1.0.0",
+        "@pdf-lib/upng": "^1.0.1",
+        "color": "^4.2.3",
+        "crypto-js": "^4.2.0",
+        "node-html-better-parser": "^1.4.0",
+        "pako": "^1.0.11",
+        "tslib": ">=2"
+      }
+    },
+    "node_modules/@cantoo/pdf-lib/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.4.0.tgz",
@@ -1201,11 +1222,6 @@
         "pako": "^1.0.6"
       }
     },
-    "node_modules/@pdf-lib/standard-fonts/node_modules/pako": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
-      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="
-    },
     "node_modules/@pdf-lib/upng": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@pdf-lib/upng/-/upng-1.0.1.tgz",
@@ -1213,11 +1229,6 @@
       "dependencies": {
         "pako": "^1.0.10"
       }
-    },
-    "node_modules/@pdf-lib/upng/node_modules/pako": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
-      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="
     },
     "node_modules/@sinclair/typebox": {
       "version": "0.27.8",
@@ -2042,11 +2053,23 @@
       "integrity": "sha512-lHl4d5/ONEbLlJvaJNtsF/Lz+WvB07u2ycqTYbdrq7UypDXailES4valYb2eWiJFxZlVmpGekfqoxQhzyFdT4Q==",
       "dev": true
     },
+    "node_modules/color": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/color/-/color-4.2.3.tgz",
+      "integrity": "sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1",
+        "color-string": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=12.5.0"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
       "dependencies": {
         "color-name": "~1.1.4"
       },
@@ -2057,8 +2080,17 @@
     "node_modules/color-name": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+    },
+    "node_modules/color-string": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.1.tgz",
+      "integrity": "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "^1.0.0",
+        "simple-swizzle": "^0.2.2"
+      }
     },
     "node_modules/combined-stream": {
       "version": "1.0.8",
@@ -2126,6 +2158,12 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/crypto-js": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.2.0.tgz",
+      "integrity": "sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q==",
+      "license": "MIT"
     },
     "node_modules/cssom": {
       "version": "0.5.0",
@@ -3689,6 +3727,22 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/html-entities": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-2.6.0.tgz",
+      "integrity": "sha512-kig+rMn/QOVRvr7c86gQ8lWXq+Hkv6CbAH1hLu+RG338StTpE8Z0b44SDVaqVu7HGKf27frdmUYEs9hTUX/cLQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/mdevils"
+        },
+        {
+          "type": "patreon",
+          "url": "https://patreon.com/mdevils"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/html-escaper": {
       "version": "2.0.2",
@@ -5575,6 +5629,15 @@
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true
     },
+    "node_modules/node-html-better-parser": {
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/node-html-better-parser/-/node-html-better-parser-1.5.3.tgz",
+      "integrity": "sha512-rvnbT4FUS+pIQPAs3bBpzeuWdgdjne0LsgrEINdsMfAvjAKHTEGVhknMEqBriGuVRWM8iRL1LKhRhZ9RB6gPVA==",
+      "license": "MIT",
+      "dependencies": {
+        "html-entities": "^2.3.2"
+      }
+    },
     "node_modules/node-int64": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
@@ -5809,6 +5872,12 @@
         "node": ">=6"
       }
     },
+    "node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "license": "(MIT AND Zlib)"
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -5893,22 +5962,6 @@
         "json-diff": "^0.5.4",
         "pdf2json": "^1.1.8"
       }
-    },
-    "node_modules/pdf-lib": {
-      "version": "1.17.1",
-      "resolved": "https://registry.npmjs.org/pdf-lib/-/pdf-lib-1.17.1.tgz",
-      "integrity": "sha512-V/mpyJAoTsN4cnP31vc0wfNA1+p20evqqnap0KLoRUN0Yk/p3wN52DOEsL4oBFcLdb76hlpKPtzJIgo67j/XLw==",
-      "dependencies": {
-        "@pdf-lib/standard-fonts": "^1.0.0",
-        "@pdf-lib/upng": "^1.0.1",
-        "pako": "^1.0.11",
-        "tslib": "^1.11.1"
-      }
-    },
-    "node_modules/pdf-lib/node_modules/pako": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
-      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="
     },
     "node_modules/pdf2json": {
       "version": "1.2.3",
@@ -6659,6 +6712,21 @@
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "dev": true
     },
+    "node_modules/simple-swizzle": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
+      "integrity": "sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==",
+      "license": "MIT",
+      "dependencies": {
+        "is-arrayish": "^0.3.1"
+      }
+    },
+    "node_modules/simple-swizzle/node_modules/is-arrayish": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
+      "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==",
+      "license": "MIT"
+    },
     "node_modules/sisteransi": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
@@ -7056,11 +7124,6 @@
       "engines": {
         "node": ">=4"
       }
-    },
-    "node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/type-check": {
       "version": "0.3.2",

--- a/package.json
+++ b/package.json
@@ -32,8 +32,8 @@
   "author": "nbesli",
   "license": "MIT",
   "dependencies": {
-    "commander": "^11.1.0",
-    "pdf-lib": "^1.17.1"
+    "@cantoo/pdf-lib": "^2.4.2",
+    "commander": "^11.1.0"
   },
   "devDependencies": {
     "fs-extra": "^11.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@radui1398/pdf-merger-js",
-  "version": "5.1.3",
+  "version": "5.1.4",
   "description": "merge multiple PDF documents, or parts of them, to a new PDF document",
   "type": "module",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@radui1398/pdf-merger",
-  "version": "5.1.2",
+  "name": "@radui1398/pdf-merger-js",
+  "version": "5.1.3",
   "description": "merge multiple PDF documents, or parts of them, to a new PDF document",
   "type": "module",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@radui1398/pdf-merger-js",
-  "version": "5.1.4",
+  "version": "5.1.5",
   "description": "merge multiple PDF documents, or parts of them, to a new PDF document",
   "type": "module",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/nbesli/pdf-merger-js.git"
+    "url": "git+https://github.com/radui1398/pdf-merger-js.git"
   },
   "keywords": [
     "pdf",
@@ -50,7 +50,7 @@
     "test": "test"
   },
   "bugs": {
-    "url": "https://github.com/nbesli/pdf-merger-js/issues"
+    "url": "https://github.com/radui1398/pdf-merger-js/issues"
   },
-  "homepage": "https://github.com/nbesli/pdf-merger-js#readme"
+  "homepage": "https://github.com/radui1398/pdf-merger-js#readme"
 }

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "pdf-merger-js",
+  "name": "@radui1398/pdf-merger",
   "version": "5.1.2",
   "description": "merge multiple PDF documents, or parts of them, to a new PDF document",
   "type": "module",
@@ -24,7 +24,10 @@
       "browser"
     ]
   },
-  "repository": "github:nbesli/pdf-merger-js",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/nbesli/pdf-merger-js.git"
+  },
   "keywords": [
     "pdf",
     "merge"
@@ -42,5 +45,12 @@
     "jsdom": "^23.0.1",
     "pdf-diff": "^0.1.1",
     "standard": "^17.1.0"
-  }
+  },
+  "directories": {
+    "test": "test"
+  },
+  "bugs": {
+    "url": "https://github.com/nbesli/pdf-merger-js/issues"
+  },
+  "homepage": "https://github.com/nbesli/pdf-merger-js#readme"
 }

--- a/test/PDFMerger.test.js
+++ b/test/PDFMerger.test.js
@@ -2,7 +2,7 @@ import path from 'path'
 
 import fs from 'fs-extra'
 import pdfDiff from 'pdf-diff'
-import { PDFDocument } from 'pdf-lib'
+import { PDFDocument } from '@cantoo/pdf-lib'
 import { jest } from '@jest/globals'
 
 import PDFMerger from '../index'


### PR DESCRIPTION
This PR makes the following changes:

Replaces pdf-lib with @cantoo/pdf-lib — this fork is better maintained and addresses several outstanding issues.

Adds support for passing loadOptions to the constructor. This is useful when, for example, you need to open a password-protected PDF without ignoring encryption.

**Context**
I needed this update for a critical issue at work, so I published a temporary package to unblock my workflow. Once this PR is merged, I’ll remove that temporary package.

I’m not claiming this is the best possible solution — just a working one for now. I’m open to feedback or alternative approaches if there’s a better way to handle this.