### PR TITLE
Switch to @cantoo/pdf-lib and add loadOptions support for encrypted PDFs (v2)

### DIFF
--- a/PDFMergerBase.js
+++ b/PDFMergerBase.js
@@ -1,4 +1,4 @@
-import { PDFDocument } from 'pdf-lib'
+import { PDFDocument } from '@cantoo/pdf-lib'
 
 import { parsePagesString } from './parsePagesString.js'
 
@@ -26,15 +26,25 @@ export default class PDFMergerBase {
   /**
    * The load options for pdf-lib.
    *
-   * @type { import('pdf-lib').LoadOptions }
+   * @type { import('@cantoo/pdf-lib').LoadOptions }
    * @protected
    */
   _loadOptions = {
     // allow merging of encrypted pdfs (issue #88)
-    ignoreEncryption: true
+    ignoreEncryption: true,
+    password: ''
   }
 
-  constructor () {
+  /**
+   * Default constructor
+   *
+   * @param { import('@cantoo/pdf-lib').LoadOptions } loadOptions
+   */
+    constructor (loadOptions = {}) {
+      this._loadOptions = {
+        ...this._loadOptions,
+        ...loadOptions
+      }
     this.reset()
   }
 

--- a/PDFMergerBase.js
+++ b/PDFMergerBase.js
@@ -40,11 +40,11 @@ export default class PDFMergerBase {
    *
    * @param { import('@cantoo/pdf-lib').LoadOptions } loadOptions
    */
-    constructor (loadOptions = {}) {
-      this._loadOptions = {
-        ...this._loadOptions,
-        ...loadOptions
-      }
+  constructor (loadOptions = {}) {
+    this._loadOptions = {
+      ...this._loadOptions,
+      ...loadOptions
+    }
     this.reset()
   }
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This node.js library can **merge multiple PDF documents**, or parts of them, to one new PDF document. You can do this by using the **command line interface** or from within your **node.js** or even directly in the **browser**.
 
-The only dependency is [pdf-lib](https://pdf-lib.js.org/) so it can run in any javascript-only environment **without any non-javascript dependencies**.
+The only dependency is [@cantoo/pdf-lib](https://www.npmjs.com/package/@cantoo/pdf-lib) so it can run in any javascript-only environment **without any non-javascript dependencies**.
 
 ## Legacy notes
 

--- a/browser.d.ts
+++ b/browser.d.ts
@@ -6,7 +6,12 @@
 
 declare module "pdf-merger-js/browser" {
   class PDFMerger {
-    constructor();
+    /**
+     * Class constructor
+     *
+     * @param { import('@cantoo/pdf-lib').LoadOptions } loadOptions
+     */
+        constructor(loadOptions: import('@cantoo/pdf-lib').LoadOptions);
     /**
      * Resets the internal state of the document, to start again.
      *

--- a/index.d.ts
+++ b/index.d.ts
@@ -6,7 +6,12 @@ import { PathLike } from "fs-extra";
 
 declare module "pdf-merger-js" {
   class PDFMerger {
-    constructor();
+    /**
+     * Class constructor
+     *
+     * @param { import('@cantoo/pdf-lib').LoadOptions } loadOptions
+     */
+        constructor(loadOptions: import('@cantoo/pdf-lib').LoadOptions);
     /**
      * Resets the internal state of the document, to start again.
      *

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "pdf-merger-js",
-  "version": "5.1.2",
+  "version": "5.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pdf-merger-js",
-      "version": "5.1.2",
+      "version": "5.1.3",
       "license": "MIT",
       "dependencies": {
-        "commander": "^11.1.0",
-        "pdf-lib": "^1.17.1"
+        "@cantoo/pdf-lib": "^2.4.2",
+        "commander": "^11.1.0"
       },
       "bin": {
         "pdf-merge": "cli.js"
@@ -24,7 +24,7 @@
         "standard": "^17.1.0"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=16"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -671,6 +671,27 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true
     },
+    "node_modules/@cantoo/pdf-lib": {
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/@cantoo/pdf-lib/-/pdf-lib-2.5.3.tgz",
+      "integrity": "sha512-SBQp8i/XdWNUhLutn5P67Pwj4X9vU046BRpfOMODJZuYVrgChtsTfgdnlW2O7x8gdXs8j7NoTaWI/b78E2oVmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@pdf-lib/standard-fonts": "^1.0.0",
+        "@pdf-lib/upng": "^1.0.1",
+        "color": "^4.2.3",
+        "crypto-js": "^4.2.0",
+        "node-html-better-parser": ">=1.4.0",
+        "pako": "^1.0.11",
+        "tslib": ">=2"
+      }
+    },
+    "node_modules/@cantoo/pdf-lib/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.4.0.tgz",
@@ -1201,11 +1222,6 @@
         "pako": "^1.0.6"
       }
     },
-    "node_modules/@pdf-lib/standard-fonts/node_modules/pako": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
-      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="
-    },
     "node_modules/@pdf-lib/upng": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@pdf-lib/upng/-/upng-1.0.1.tgz",
@@ -1213,11 +1229,6 @@
       "dependencies": {
         "pako": "^1.0.10"
       }
-    },
-    "node_modules/@pdf-lib/upng/node_modules/pako": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
-      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="
     },
     "node_modules/@sinclair/typebox": {
       "version": "0.27.8",
@@ -2042,11 +2053,23 @@
       "integrity": "sha512-lHl4d5/ONEbLlJvaJNtsF/Lz+WvB07u2ycqTYbdrq7UypDXailES4valYb2eWiJFxZlVmpGekfqoxQhzyFdT4Q==",
       "dev": true
     },
+    "node_modules/color": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/color/-/color-4.2.3.tgz",
+      "integrity": "sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1",
+        "color-string": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=12.5.0"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
       "dependencies": {
         "color-name": "~1.1.4"
       },
@@ -2057,8 +2080,17 @@
     "node_modules/color-name": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+    },
+    "node_modules/color-string": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.1.tgz",
+      "integrity": "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "^1.0.0",
+        "simple-swizzle": "^0.2.2"
+      }
     },
     "node_modules/combined-stream": {
       "version": "1.0.8",
@@ -2126,6 +2158,12 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/crypto-js": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.2.0.tgz",
+      "integrity": "sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q==",
+      "license": "MIT"
     },
     "node_modules/cssom": {
       "version": "0.5.0",
@@ -3689,6 +3727,22 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/html-entities": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-2.6.0.tgz",
+      "integrity": "sha512-kig+rMn/QOVRvr7c86gQ8lWXq+Hkv6CbAH1hLu+RG338StTpE8Z0b44SDVaqVu7HGKf27frdmUYEs9hTUX/cLQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/mdevils"
+        },
+        {
+          "type": "patreon",
+          "url": "https://patreon.com/mdevils"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/html-escaper": {
       "version": "2.0.2",
@@ -5575,6 +5629,15 @@
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true
     },
+    "node_modules/node-html-better-parser": {
+      "version": "1.5.8",
+      "resolved": "https://registry.npmjs.org/node-html-better-parser/-/node-html-better-parser-1.5.8.tgz",
+      "integrity": "sha512-t/wAKvaTSKco43X+yf9+76RiMt18MtMmzd4wc7rKj+fWav6DV4ajDEKdWlLzSE8USDF5zr/06uGj0Wr/dGAFtw==",
+      "license": "MIT",
+      "dependencies": {
+        "html-entities": "^2.3.2"
+      }
+    },
     "node_modules/node-int64": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
@@ -5809,6 +5872,12 @@
         "node": ">=6"
       }
     },
+    "node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "license": "(MIT AND Zlib)"
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -5893,22 +5962,6 @@
         "json-diff": "^0.5.4",
         "pdf2json": "^1.1.8"
       }
-    },
-    "node_modules/pdf-lib": {
-      "version": "1.17.1",
-      "resolved": "https://registry.npmjs.org/pdf-lib/-/pdf-lib-1.17.1.tgz",
-      "integrity": "sha512-V/mpyJAoTsN4cnP31vc0wfNA1+p20evqqnap0KLoRUN0Yk/p3wN52DOEsL4oBFcLdb76hlpKPtzJIgo67j/XLw==",
-      "dependencies": {
-        "@pdf-lib/standard-fonts": "^1.0.0",
-        "@pdf-lib/upng": "^1.0.1",
-        "pako": "^1.0.11",
-        "tslib": "^1.11.1"
-      }
-    },
-    "node_modules/pdf-lib/node_modules/pako": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
-      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="
     },
     "node_modules/pdf2json": {
       "version": "1.2.3",
@@ -6659,6 +6712,21 @@
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "dev": true
     },
+    "node_modules/simple-swizzle": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.4.tgz",
+      "integrity": "sha512-nAu1WFPQSMNr2Zn9PGSZK9AGn4t/y97lEm+MXTtUDwfP0ksAIX4nO+6ruD9Jwut4C49SB1Ws+fbXsm/yScWOHw==",
+      "license": "MIT",
+      "dependencies": {
+        "is-arrayish": "^0.3.1"
+      }
+    },
+    "node_modules/simple-swizzle/node_modules/is-arrayish": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.4.tgz",
+      "integrity": "sha512-m6UrgzFVUYawGBh1dUsWR5M2Clqic9RVXC/9f8ceNlv2IcO9j9J/z8UoCLPqtsPBFNzEpfR3xftohbfqDx8EQA==",
+      "license": "MIT"
+    },
     "node_modules/sisteransi": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
@@ -7056,11 +7124,6 @@
       "engines": {
         "node": ">=4"
       }
-    },
-    "node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/type-check": {
       "version": "0.3.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pdf-merger-js",
-  "version": "5.1.2",
+  "version": "5.1.3",
   "description": "merge multiple PDF documents, or parts of them, to a new PDF document",
   "type": "module",
   "engines": {
@@ -33,7 +33,7 @@
   "license": "MIT",
   "dependencies": {
     "commander": "^11.1.0",
-    "pdf-lib": "^1.17.1"
+    "@cantoo/pdf-lib": "^2.4.2"
   },
   "devDependencies": {
     "fs-extra": "^11.2.0",

--- a/test/PDFMerger.test.js
+++ b/test/PDFMerger.test.js
@@ -2,7 +2,7 @@ import path from 'path'
 
 import fs from 'fs-extra'
 import pdfDiff from 'pdf-diff'
-import { PDFDocument } from 'pdf-lib'
+import { PDFDocument } from '@cantoo/pdf-lib'
 import { jest } from '@jest/globals'
 
 import PDFMerger from '../index'


### PR DESCRIPTION
Inspired by: #151 

I just removed the metadata for the specific user's fork.

This is the context:

> This PR makes the following changes:
>
> Replaces pdf-lib with @cantoo/pdf-lib — this fork is better maintained and addresses several outstanding issues.
>
> Adds support for passing loadOptions to the constructor. This is useful when, for example, you need to open a password-> protected PDF without ignoring encryption.
> 
> Context
> I needed this update for a critical issue at work, so I published a temporary package to unblock my workflow. Once this PR is merged, I’ll remove that temporary package.
>
>I’m not claiming this is the best possible solution — just a working one for now. I’m open to feedback or alternative approaches if there’s a better way to handle this.

Tests were fine on my end:

<img width="771" height="310" alt="image" src="https://github.com/user-attachments/assets/9ac1d62f-affa-4d07-be44-25a2538e4195" />
